### PR TITLE
Fix prefer lowest compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "require": {
         "php": "^7.1",
-        "laminas/laminas-zendframework-bridge": "^1.0",
+        "laminas/laminas-zendframework-bridge": "^1.0.1",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0"
     },


### PR DESCRIPTION
Trying to fix
```
1) IdeHelper\Test\TestCase\Annotator\ClassAnnotatorTask\TestClassAnnotatorTaskTest::testAnnotate
TypeError: Return value of Zend\Diactoros\marshalUriFromSapi() must be an instance of Zend\Diactoros\Uri, instance of Laminas\Diactoros\Uri returned
/home/travis/build/dereuromark/cakephp-ide-helper/vendor/laminas/laminas-diactoros/src/functions/marshal_uri_from_sapi.legacy.php:20
```
https://travis-ci.org/dereuromark/cakephp-ide-helper/jobs/635958965?utm_medium=notification&utm_source=github_status

But I am not sure if this actually fixes things.
Tests are still failing https://github.com/dereuromark/cakephp-ide-helper/pull/168

I would expect prefer-lowest to not have aliasing issues as this compromises those important travis checks.