### PR TITLE
IDN domains were messed up with strtolower

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -21,6 +21,7 @@ use function is_numeric;
 use function is_object;
 use function is_string;
 use function ltrim;
+use function mb_strtolower;
 use function parse_url;
 use function preg_match;
 use function preg_replace;
@@ -462,7 +463,7 @@ class Uri implements UriInterface
 
         $this->scheme    = isset($parts['scheme']) ? $this->filterScheme($parts['scheme']) : '';
         $this->userInfo  = isset($parts['user']) ? $this->filterUserInfoPart($parts['user']) : '';
-        $this->host      = isset($parts['host']) ? strtolower($parts['host']) : '';
+        $this->host      = isset($parts['host']) ? mb_strtolower($parts['host']) : '';
         $this->port      = isset($parts['port']) ? $parts['port'] : null;
         $this->path      = isset($parts['path']) ? $this->filterPath($parts['path']) : '';
         $this->query     = isset($parts['query']) ? $this->filterQuery($parts['query']) : '';

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -317,7 +317,7 @@ class Uri implements UriInterface
         }
 
         $new = clone $this;
-        $new->host = strtolower($host);
+        $new->host = mb_strtolower($host);
 
         return $new;
     }

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -21,7 +21,6 @@ use function is_numeric;
 use function is_object;
 use function is_string;
 use function ltrim;
-use function mb_strtolower;
 use function parse_url;
 use function preg_match;
 use function preg_replace;
@@ -317,7 +316,7 @@ class Uri implements UriInterface
         }
 
         $new = clone $this;
-        $new->host = mb_strtolower($host);
+        $new->host = $this->lowercase($host);
 
         return $new;
     }
@@ -463,7 +462,7 @@ class Uri implements UriInterface
 
         $this->scheme    = isset($parts['scheme']) ? $this->filterScheme($parts['scheme']) : '';
         $this->userInfo  = isset($parts['user']) ? $this->filterUserInfoPart($parts['user']) : '';
-        $this->host      = isset($parts['host']) ? mb_strtolower($parts['host']) : '';
+        $this->host      = isset($parts['host']) ? $this->lowercase($parts['host']) : '';
         $this->port      = isset($parts['port']) ? $parts['port'] : null;
         $this->path      = isset($parts['path']) ? $this->filterPath($parts['path']) : '';
         $this->query     = isset($parts['query']) ? $this->filterQuery($parts['query']) : '';
@@ -695,5 +694,10 @@ class Uri implements UriInterface
     private function urlEncodeChar(array $matches) : string
     {
         return rawurlencode($matches[0]);
+    }
+
+    private function lowercase(string $string) : string
+    {
+        return strtolower($string);
     }
 }

--- a/test/UriTest.php
+++ b/test/UriTest.php
@@ -138,9 +138,10 @@ class UriTest extends TestCase
 
     public function testWithHostWithGermanUmlaut()
     {
-        $uri = new Uri('https://körberl.taugl.online');
-        $new = $uri->withHost('körberl.taugl.online');
-        $this->assertSame($uri, $new);
+        $uri = new Uri('https://www.example.com');
+        $newHost = 'körberl.taugl.online';
+        $new = $uri->withHost($newHost);
+        $this->assertSame($newHost, $new->getHost());
     }
 
     public function validPorts()

--- a/test/UriTest.php
+++ b/test/UriTest.php
@@ -606,10 +606,10 @@ class UriTest extends TestCase
     public function testUriWithGermanUmlaut()
     {
         $uri = new Uri('https://körberl.taugl.online/');
-        
+
         $this->assertSame('körberl.taugl.online', $uri->getHost());
     }
-    
+
     /**
      * @dataProvider utf8PathsDataProvider
      */

--- a/test/UriTest.php
+++ b/test/UriTest.php
@@ -603,6 +603,13 @@ class UriTest extends TestCase
         $this->assertSame('ουτοπία.δπθ.gr', $uri->getHost());
     }
 
+    public function testUriWithGermanUmlaut()
+    {
+        $uri = new Uri('https://körberl.taugl.online/');
+        
+        $this->assertSame('körberl.taugl.online', $uri->getHost());
+    }
+    
     /**
      * @dataProvider utf8PathsDataProvider
      */

--- a/test/UriTest.php
+++ b/test/UriTest.php
@@ -136,6 +136,13 @@ class UriTest extends TestCase
         $this->assertSame('https://user:pass@local.example.com:3001/foo?bar=baz#quz', (string) $new);
     }
 
+    public function testWithHostWithGermanUmlaut()
+    {
+        $uri = new Uri('https://körberl.taugl.online');
+        $new = $uri->withHost('körberl.taugl.online');
+        $this->assertSame($uri, $new);
+    }
+
     public function validPorts()
     {
         return [


### PR DESCRIPTION
IDN domains like `körberl.taugl.online` were messed up to `k▒rberl.taugl.online`.