### PR TITLE
Feature - Add `ConfigProvider`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,9 @@
             "dev-master": "2.1.x-dev",
             "dev-develop": "2.2.x-dev",
             "dev-release-1.8": "1.8.x-dev"
+        },
+        "laminas": {
+            "config-provider": "Laminas\\Diactoros\\ConfigProvider"
         }
     },
     "require": {

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-diactoros for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-diactoros/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-diactoros/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Laminas\Diactoros;
+
+use Psr\Http\Message\ServerRequestFactoryInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\UploadedFileFactoryInterface;
+use Psr\Http\Message\UriFactoryInterface;
+
+class ConfigProvider
+{
+    /**
+     * Retrieve configuration for laminas-diactoros.
+     *
+     * @return array
+     */
+    public function __invoke() : array
+    {
+        return [
+            'dependencies' => $this->getDependencies(),
+        ];
+    }
+
+    /**
+     * Returns the container dependencies.
+     * Maps factory interfaces to factories.
+     */
+    public function getDependencies() : array
+    {
+        return [
+            'invokables' => [
+                RequestFactoryInterface::class => RequestFactory::class,
+                ResponseFactoryInterface::class => ResponseFactory::class,
+                StreamFactoryInterface::class => StreamFactory::class,
+                ServerRequestFactoryInterface::class => ServerRequestFactory::class,
+                UploadedFileFactoryInterface::class => UploadedFileFactory::class,
+                UriFactoryInterface::class => UriFactory::class
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| New Feature   | yes

### Description

Add a [ConfigProvider](https://docs.laminas.dev/laminas-config-aggregator/config-providers/) and [package config](https://docs.laminas.dev/laminas-component-installer/#config-providers) that will map PSR-17 HTTP Factory interfaces to the Diactoros implementations when used with compatible container implementation.

Example:
```php
$responseFactory = $container->get(\Psr\Http\Message\ResponseFactoryInterface::class);
```

Allows, for example, Request Handler factories to request interfaces from the container. eg:

```php
declare(strict_types=1);

namespace My\Module\Handler;

use Psr\Container\ContainerInterface;
use Psr\Http\Message\ResponseFactoryInterface;

class FooHandlerFactory
{
    public function __invoke(ContainerInterface $container) : FooHandler
    {
        return new FooHandler(
            $container->get(ResponseFactoryInterface::class)
        );
    }
}
```
