### PR TITLE
Bump PHP minimum to 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,26 +13,14 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 7.1
+    - php: 7.3
       env:
         - DEPS=lowest
-    - php: 7.1
+    - php: 7.3
       env:
         - DEPS=latest
         - CS_CHECK=true
         - TEST_COVERAGE=true
-    - php: 7.2
-      env:
-        - DEPS=lowest
-    - php: 7.2
-      env:
-        - DEPS=latest
-    - php: 7.3
-      env:
-        - DEPS=lowest
-    - php: 7.3
-      env:
-        - DEPS=latest
     - php: 7.4
       env:
         - DEPS=lowest

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         }
     },
     "require": {
-        "php": "^7.1",
+        "php": "~7.3.0 || ~7.4.0",
         "laminas/laminas-zendframework-bridge": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0"


### PR DESCRIPTION
Per the policy agreed upon during the inaugural TSC meeting, this patch bumps the minimum supported PHP version to 7.3 for the next minor release.