### PR TITLE
Update documentation example about ServerRequestFactory::fromGlobals().

### DIFF
--- a/docs/book/v1/api.md
+++ b/docs/book/v1/api.md
@@ -119,7 +119,7 @@ $request = ServerRequestFactory::fromGlobals();
 
 // Returns new ServerRequest instance, using values provided (in this
 // case, equivalent to the previous!)
-$request = RequestFactory::fromGlobals(
+$request = ServerRequestFactory::fromGlobals(
     $_SERVER,
     $_GET,
     $_POST,

--- a/docs/book/v2/api.md
+++ b/docs/book/v2/api.md
@@ -117,7 +117,7 @@ $request = ServerRequestFactory::fromGlobals();
 
 // Returns new ServerRequest instance, using values provided (in this
 // case, equivalent to the previous!)
-$request = RequestFactory::fromGlobals(
+$request = ServerRequestFactory::fromGlobals(
     $_SERVER,
     $_GET,
     $_POST,


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes

### Description

In the API Documentation, in ServerRequestFactory::fromGlobals() example, I think that instead of:

`$request = RequestFactory::fromGlobals(`

should be:

`$request = ServerRequestFactory::fromGlobals(`
