### PR TITLE
Simplify redirects of legacy docs

### DIFF
--- a/docs/book/api.md
+++ b/docs/book/api.md
@@ -1,6 +1,0 @@
-<noscript><meta http-equiv="refresh" content="0; url=/laminas-diactoros/v2/api/"></noscript>
-<script>
-  document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = '/laminas-diactoros/v2/api/';
-  });
-</script>

--- a/docs/book/custom-responses.md
+++ b/docs/book/custom-responses.md
@@ -1,6 +1,0 @@
-<noscript><meta http-equiv="refresh" content="0; url=/laminas-diactoros/v2/custom-responses/"></noscript>
-<script>
-  document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = '/laminas-diactoros/v2/custom-responses/';
-  });
-</script>

--- a/docs/book/emitting-responses.md
+++ b/docs/book/emitting-responses.md
@@ -1,6 +1,0 @@
-<noscript><meta http-equiv="refresh" content="0; url=/laminas-diactoros/v1/emitting-responses/"></noscript>
-<script>
-  document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = '/laminas-diactoros/v1/emitting-responses/';
-  });
-</script>

--- a/docs/book/install.md
+++ b/docs/book/install.md
@@ -1,6 +1,0 @@
-<noscript><meta http-equiv="refresh" content="0; url=/laminas-diactoros/v2/install/"></noscript>
-<script>
-  document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = '/laminas-diactoros/v2/install/';
-  });
-</script>

--- a/docs/book/overview.md
+++ b/docs/book/overview.md
@@ -1,6 +1,0 @@
-<noscript><meta http-equiv="refresh" content="0; url=/laminas-diactoros/v2/overview/"></noscript>
-<script>
-  document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = '/laminas-diactoros/v2/overview/';
-  });
-</script>

--- a/docs/book/serialization.md
+++ b/docs/book/serialization.md
@@ -1,6 +1,0 @@
-<noscript><meta http-equiv="refresh" content="0; url=/laminas-diactoros/v2/serialization/"></noscript>
-<script>
-  document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = '/laminas-diactoros/v2/serialization/';
-  });
-</script>

--- a/docs/book/usage.md
+++ b/docs/book/usage.md
@@ -1,6 +1,0 @@
-<noscript><meta http-equiv="refresh" content="0; url=/laminas-diactoros/v2/usage/"></noscript>
-<script>
-  document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = '/laminas-diactoros/v2/usage/';
-  });
-</script>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,14 +28,17 @@ nav:
       - "Emitting Responses": v1/emitting-responses.md
       - Serialization: v1/serialization.md
       - API: v1/api.md
-  - "_hidden-legacy-page-links":
-    - "_overview": overview.md
-    - "_installation": install.md
-    - "_usage": usage.md
-    - "_reference-custom-responses": custom-responses.md
-    - "_reference-emitting-responses": emitting-responses.md
-    - "_reference-serialization": serialization.md
-    - "_reference-api": api.md
 site_name: laminas-diactoros
 site_description: "PSR-7 HTTP message implementations"
 repo_url: "https://github.com/laminas/laminas-diactoros"
+plugins:
+  - search
+  - redirects:
+      redirect_maps:
+        overview.md: v2/overview.md
+        install.md: v2/install.md
+        usage.md: v2/usage.md
+        custom-responses.md: v2/custom-responses.md
+        emitting-responses.md: v1/emitting-responses.md
+        serialization.md: v2/serialization.md
+        api.md: v2/api.md


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

The docs folder contains several manual redirects, i.d. HTML documents with a hard-coded redirect for legacy URLs. With the [adoption of the MkDocs redirect plugin](https://github.com/laminas/documentation-theme/pull/65) there is a simpler solution available.

This PR moves the redirects for legacy URLs in `mkdocs.yml` and removes the manually created HTML documents from Git.