### PR TITLE
Allow double slashes in the path according to the RFC3986

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -573,24 +573,11 @@ class Uri implements UriInterface
     {
         $path = $this->filterInvalidUtf8($path);
 
-        $path = preg_replace_callback(
+        return preg_replace_callback(
             '/(?:[^' . self::CHAR_UNRESERVED . ')(:@&=\+\$,\/;%]+|%(?![A-Fa-f0-9]{2}))/u',
             [$this, 'urlEncodeChar'],
             $path
         );
-
-        if ('' === $path) {
-            // No path
-            return $path;
-        }
-
-        if ($path[0] !== '/') {
-            // Relative path
-            return $path;
-        }
-
-        // Ensure only one leading slash, to prevent XSS attempts.
-        return '/' . ltrim($path, '/');
     }
 
     /**

--- a/test/UriTest.php
+++ b/test/UriTest.php
@@ -546,13 +546,6 @@ class UriTest extends TestCase
         $this->assertSame($expected, $uri->getFragment());
     }
 
-    public function testProperlyTrimsLeadingSlashesToPreventXSS()
-    {
-        $url = 'http://example.org//zend.com';
-        $uri = new Uri($url);
-        $this->assertSame('http://example.org/zend.com', (string) $uri);
-    }
-
     public function invalidStringComponentValues()
     {
         $methods = [
@@ -690,5 +683,14 @@ class UriTest extends TestCase
         $expected = 'https://0:0@0:1/0?0#0';
         $uri = new Uri($expected);
         $this->assertSame($expected, (string) $uri);
+    }
+
+    public function testPathWithMultipleSlashes()
+    {
+        $expected = 'http://example.org//valid///path';
+        $uri = new Uri($expected);
+
+        $this->assertSame($expected, (string) $uri);
+        $this->assertSame('//valid///path', $uri->getPath());
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | maybe
| New Feature   | no
| RFC           | no
| QA            | no

### Description
This resolves #74
maybe it could be a BC break, because the behavior of the `getPath` has changed.
its since this commit: https://github.com/laminas/laminas-diactoros/commit/68fc7424a66735926589dbaf74c0659c09e75764
