### PR TITLE
Fix unserialization of header continuation / line folding

### DIFF
--- a/src/AbstractSerializer.php
+++ b/src/AbstractSerializer.php
@@ -109,7 +109,7 @@ abstract class AbstractSerializer
 
             // Append continuation to last header value found
             $value = array_pop($headers[$currentHeader]);
-            $headers[$currentHeader][] = $value . ltrim($line);
+            $headers[$currentHeader][] = $value . ' ' . ltrim($line);
         }
 
         // use RelativeStream to avoid copying initial stream into memory

--- a/test/Request/SerializerTest.php
+++ b/test/Request/SerializerTest.php
@@ -244,7 +244,7 @@ class SerializerTest extends TestCase
         $this->assertInstanceOf(Request::class, $request);
 
         $this->assertTrue($request->hasHeader('X-Foo-Bar'));
-        $this->assertSame('Baz;Bat', $request->getHeaderLine('X-Foo-Bar'));
+        $this->assertSame('Baz; Bat', $request->getHeaderLine('X-Foo-Bar'));
     }
 
     public function messagesWithInvalidHeaders() : array

--- a/test/Response/SerializerTest.php
+++ b/test/Response/SerializerTest.php
@@ -118,7 +118,7 @@ class SerializerTest extends TestCase
         $this->assertInstanceOf(Response::class, $response);
 
         $this->assertTrue($response->hasHeader('X-Foo-Bar'));
-        $this->assertSame('Baz;Bat', $response->getHeaderLine('X-Foo-Bar'));
+        $this->assertSame('Baz; Bat', $response->getHeaderLine('X-Foo-Bar'));
     }
 
     public function testCanDeserializeResponseWithoutBody()


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

As per RFC 7230:

> A user agent that receives an obs-fold in a response message that is
> not within a message/http container MUST replace each received
> obs-fold with one or more SP octets prior to interpreting the field
> value.

Thus a space must be inserted when concatenating the continuation line in
AbstractSerializer::splitStream().