### PR TITLE
Normalize line-folded headers values to not contain newlines

### DIFF
--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -18,6 +18,7 @@ use function is_resource;
 use function is_string;
 use function preg_match;
 use function sprintf;
+use function str_replace;
 use function strtolower;
 
 /**
@@ -398,8 +399,13 @@ trait MessageTrait
         return array_map(function ($value) {
             HeaderSecurity::assertValid($value);
 
+            $value = (string)$value;
+
+            // Normalize line folding to a single space (RFC 7230#3.2.4).
+            $value = str_replace(["\r\n\t", "\r\n "], ' ', $value);
+
             // Remove optional whitespace (OWS, RFC 7230#3.2.3) around the header value.
-            return trim((string) $value, "\t ");
+            return trim($value, "\t ");
         }, array_values($values));
     }
 

--- a/test/MessageTraitTest.php
+++ b/test/MessageTraitTest.php
@@ -327,13 +327,13 @@ class MessageTraitTest extends TestCase
     public function testWithHeaderAllowsHeaderContinuations(): void
     {
         $message = $this->message->withHeader('X-Foo-Bar', "value,\r\n second value");
-        $this->assertSame("value,\r\n second value", $message->getHeaderLine('X-Foo-Bar'));
+        $this->assertSame("value, second value", $message->getHeaderLine('X-Foo-Bar'));
     }
 
     public function testWithAddedHeaderAllowsHeaderContinuations(): void
     {
         $message = $this->message->withAddedHeader('X-Foo-Bar', "value,\r\n second value");
-        $this->assertSame("value,\r\n second value", $message->getHeaderLine('X-Foo-Bar'));
+        $this->assertSame("value, second value", $message->getHeaderLine('X-Foo-Bar'));
     }
 
     /** @return non-empty-array<non-empty-string, array{non-empty-string}> */
@@ -355,6 +355,28 @@ class MessageTraitTest extends TestCase
     {
         $message = $this->message->withHeader('X-Foo-Bar', $value);
         $this->assertSame(trim($value, "\t "), $message->getHeaderLine('X-Foo-Bar'));
+    }
+
+    /** @return non-empty-array<non-empty-string, array{non-empty-string}> */
+    public function headersWithContinuation(): array
+    {
+        return [
+            'space' => ["foo\r\n bar"],
+            'tab' => ["foo\r\n\tbar"],
+        ];
+    }
+
+    /**
+     * @dataProvider headersWithContinuation
+     */
+    public function testWithHeaderNormalizesContinuationToNotContainNewlines(string $value): void
+    {
+        $message = $this->message->withHeader('X-Foo-Bar', $value);
+        // Newlines must no longer appear.
+        $this->assertStringNotContainsString("\r", $message->getHeaderLine('X-Foo-Bar'));
+        $this->assertStringNotContainsString("\n", $message->getHeaderLine('X-Foo-Bar'));
+        // But there must be at least one space.
+        $this->assertStringContainsString(' ', $message->getHeaderLine('X-Foo-Bar'));
     }
 
     /** @return non-empty-array<non-empty-string, array{int|float}> */


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | maybe?
| New Feature   | no
| RFC           | no
| QA            | no

### Description

As per RFC 7230#3.2.4:

> A server that receives an obs-fold in a request message that is not
> within a message/http container MUST […] replace
> each received obs-fold with one or more SP octets prior to
> interpreting the field value or forwarding the message downstream.
> […]
> A user agent that receives an obs-fold in a response message that is
> not within a message/http container MUST replace each received
> obs-fold with one or more SP octets prior to interpreting the field
> value.

Furthermore this change improves interoperability with PSR-7 implementations
that reject line folding.

The updated behavior matches the suggested behavior with regard to the handling
of line-folding in the new php-fig/fig-standards#1274 erratum.
