### PR TITLE
Correctly `use function trim;`

### DIFF
--- a/src/AbstractSerializer.php
+++ b/src/AbstractSerializer.php
@@ -8,10 +8,10 @@ use Psr\Http\Message\StreamInterface;
 
 use function array_pop;
 use function implode;
-use function ltrim;
 use function preg_match;
 use function sprintf;
 use function str_replace;
+use function trim;
 use function ucwords;
 
 /**

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -19,6 +19,7 @@ use function is_string;
 use function preg_match;
 use function sprintf;
 use function strtolower;
+use function trim;
 
 /**
  * Trait implementing the various methods defined in MessageInterface.


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

This is a follow-up for laminas/laminas-diactoros#84. This issue apparently was
not detected by the CI and neither during review.