### PR TITLE
Add `export-ignore` attribute for `.laminas-ci.json`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,7 +2,7 @@
 /.gitattributes export-ignore
 /.github/ export-ignore
 /.gitignore export-ignore
-/.laminas-ci.json
+/.laminas-ci.json export-ignore
 /docs/ export-ignore
 /mkdocs.yml export-ignore
 /phpcs.xml export-ignore


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

The file was already listed in `.gitattributes` since
56058610cb0be8adbb65e6e169c1df0a49807d4e, but without any actual attributes
which I assume to be an oversight.