### PR TITLE
Use constant expression for JsonResponse::DEFAULT_JSON_FLAGS

### DIFF
--- a/src/Response/JsonResponse.php
+++ b/src/Response/JsonResponse.php
@@ -16,6 +16,11 @@ use function json_last_error_msg;
 use function sprintf;
 
 use const JSON_ERROR_NONE;
+use const JSON_HEX_AMP;
+use const JSON_HEX_APOS;
+use const JSON_HEX_QUOT;
+use const JSON_HEX_TAG;
+use const JSON_UNESCAPED_SLASHES;
 
 /**
  * JSON response.
@@ -29,15 +34,15 @@ class JsonResponse extends Response
     use InjectContentTypeTrait;
 
     /**
-     * Default flags for json_encode; value of:
-     *
-     * <code>
-     * JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT | JSON_UNESCAPED_SLASHES
-     * </code>
+     * Default flags for json_encode
      *
      * @const int
      */
-    public const DEFAULT_JSON_FLAGS = 79;
+    public const DEFAULT_JSON_FLAGS = JSON_HEX_TAG
+        | JSON_HEX_APOS
+        | JSON_HEX_AMP
+        | JSON_HEX_QUOT
+        | JSON_UNESCAPED_SLASHES;
 
     /**
      * @var mixed


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

Using a constant expression is legal in all PHP versions that are supported by Diactoros and prevents the expected values and actual values from diverging.