### PR TITLE
Fix typo in property name in `UploadedFileTest::setUp()`

### DIFF
--- a/test/UploadedFileTest.php
+++ b/test/UploadedFileTest.php
@@ -36,7 +36,7 @@ class UploadedFileTest extends TestCase
 
     protected function setUp() : void
     {
-        $this->tmpfile = null;
+        $this->tmpFile = null;
     }
 
     protected function tearDown() : void


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

This fixes a deprecation warning in PHP 8.2:

> Deprecated: Creation of dynamic property LaminasTest\Diactoros\UploadedFileTest::$tmpfile is deprecated in /pwd/test/UploadedFileTest.php on line 39