### PR TITLE
Clarify how zero-valued header parsing changed from diactoros 1.x to 2.x

### DIFF
--- a/docs/book/v2/migration.md
+++ b/docs/book/v2/migration.md
@@ -29,10 +29,6 @@ The first approach may fail if libraries you depend on specifically require a
 version 1 release. The second approach may leave you on a version 1 release in
 situations where other libraries you depend on require version 1.
 
-In all cases, if you are only using the PSR-7 implementations and/or the
-`ServerRequestFactory::fromGlobals()` functionality, upgrading to version 2 will
-pose no backwards compatibility issues.
-
 ## Changed
 
 - `Laminas\Diactoros\RequestTrait` now raises an `InvalidArgumentException` in
@@ -41,6 +37,12 @@ pose no backwards compatibility issues.
 - `Laminas\Diactoros\Serializer\Request::toString()` no longer raises an
   `UnexpectedValueException` due to an unexpected HTTP method; this is due to the
   fact that the HTTP method value can no longer be set to an invalid value.
+
+- `Laminas\Diactoros\marshalHeadersFromSapi()` is parsing headers differently compared to the legacy implementation.
+   As a consequence Headers with `'0'` as values will be part of the parsed Headers.
+   In former versions those headers were ignored.
+   Usages of `\Laminas\Diactoros\MessageTrait::hasHeader()` and `\Laminas\Diactoros\MessageTrait::getHeader()`
+   might be affected if you are using `ServerRequestFactory::fromGlobals()` functionality.
 
 ## Removed
 


### PR DESCRIPTION
Signed-off-by: Florian Hofsaess <florian.hofsaess@check24.de>

|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Since the old implementation didn't add headers with `'0'` as content there is a significant change in parsing headers. That said the `hasHeader` will lead to true starting with ^2

Especially when headers are used for handling specific logic it will lead to a significant impact.

I'd say that the old implementation was buggy here. Fixing this bug should be mentioned in documentation to enable users to review their usages of `hasHeader` and `getHeaders` activly