### PR TITLE
Resolve Host header and X-Forwarded-Proto regressions

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -243,9 +243,13 @@
   </file>
   <file src="src/ServerRequestFactory.php">
     <LessSpecificReturnStatement occurrences="1"/>
-    <MixedArgument occurrences="1">
+    <MixedArgument occurrences="2">
       <code>$headers['cookie']</code>
+      <code>$host</code>
     </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>$headers</code>
+    </MixedArgumentTypeCoercion>
     <MixedAssignment occurrences="3">
       <code>$iisUrlRewritten</code>
       <code>$requestUri</code>
@@ -257,6 +261,9 @@
     <MixedReturnStatement occurrences="1">
       <code>$defaults</code>
     </MixedReturnStatement>
+    <MixedReturnTypeCoercion occurrences="1">
+      <code>self::marshalHostAndPortFromHeader($host)</code>
+    </MixedReturnTypeCoercion>
     <MoreSpecificReturnType occurrences="1">
       <code>ServerRequest</code>
     </MoreSpecificReturnType>

--- a/src/ServerRequestFactory.php
+++ b/src/ServerRequestFactory.php
@@ -269,7 +269,7 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
      * @return array Array of two items, host and port, in that order (can be
      *     passed to a list() operation).
      */
-    private static function marshalHostAndPortFromHeader($host)
+    private static function marshalHostAndPortFromHeader($host): array
     {
         if (is_array($host)) {
             $host = implode(', ', $host);

--- a/src/ServerRequestFactory.php
+++ b/src/ServerRequestFactory.php
@@ -75,7 +75,7 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
         return $requestFilter(new ServerRequest(
             $server,
             $files,
-            self::marshalUriFromSapi($server),
+            self::marshalUriFromSapi($server, $headers),
             marshalMethodFromSapi($server),
             'php://input',
             $headers,
@@ -105,9 +105,10 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
     /**
      * Marshal a Uri instance based on the values present in the $_SERVER array and headers.
      *
+     * @param array<string, string|list<string>> $headers
      * @param array $server SAPI parameters
      */
-    private static function marshalUriFromSapi(array $server) : Uri
+    private static function marshalUriFromSapi(array $server, array $headers) : Uri
     {
         $uri = new Uri('');
 
@@ -122,7 +123,7 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
         $uri = $uri->withScheme($https ? 'https' : 'http');
 
         // Set the host
-        [$host, $port] = self::marshalHostAndPort($server);
+        [$host, $port] = self::marshalHostAndPort($server, $headers);
         if (! empty($host)) {
             $uri = $uri->withHost($host);
             if (! empty($port)) {
@@ -157,12 +158,18 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
     /**
      * Marshal the host and port from the PHP environment.
      *
+     * @param array<string, string|list<string>> $headers
      * @return array{string, int|null} Array of two items, host and port,
      *     in that order (can be passed to a list() operation).
      */
-    private static function marshalHostAndPort(array $server) : array
+    private static function marshalHostAndPort(array $server, array $headers) : array
     {
         static $defaults = ['', null];
+
+        $host = self::getHeaderFromArray('host', $headers, false);
+        if ($host !== false) {
+            return self::marshalHostAndPortFromHeader($host);
+        }
 
         if (! isset($server['SERVER_NAME'])) {
             return $defaults;
@@ -255,5 +262,49 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
         }
 
         return 'on' === strtolower($https);
+    }
+
+    /**
+     * @param string|list<string> $host
+     * @return array Array of two items, host and port, in that order (can be
+     *     passed to a list() operation).
+     */
+    private static function marshalHostAndPortFromHeader($host)
+    {
+        if (is_array($host)) {
+            $host = implode(', ', $host);
+        }
+
+        $port = null;
+
+        // works for regname, IPv4 & IPv6
+        if (preg_match('|\:(\d+)$|', $host, $matches)) {
+            $host = substr($host, 0, -1 * (strlen($matches[1]) + 1));
+            $port = (int) $matches[1];
+        }
+
+        return [$host, $port];
+    }
+
+    /**
+     * Retrieve a header value from an array of headers using a case-insensitive lookup.
+     *
+     * @param array<string, string|list<string>> $headers Key/value header pairs
+     * @param mixed $default Default value to return if header not found
+     * @return mixed
+     */
+    private static function getHeaderFromArray(string $name, array $headers, $default = null)
+    {
+        $header  = strtolower($name);
+        $headers = array_change_key_case($headers, CASE_LOWER);
+        if (! array_key_exists($header, $headers)) {
+            return $default;
+        }
+
+        if (is_string($headers[$header])) {
+            return $headers[$header];
+        }
+
+        return implode(', ', $headers[$header]);
     }
 }

--- a/src/ServerRequestFilter/FilterUsingXForwardedHeaders.php
+++ b/src/ServerRequestFilter/FilterUsingXForwardedHeaders.php
@@ -83,7 +83,8 @@ final class FilterUsingXForwardedHeaders implements FilterServerRequestInterface
                     $uri = $uri->withPort((int) $header);
                     break;
                 case self::HEADER_PROTO:
-                    $uri = $uri->withScheme($header);
+                    $scheme = strtolower($header) === 'https' ? 'https' : 'http';
+                    $uri = $uri->withScheme($scheme);
                     break;
             }
         }

--- a/test/ServerRequestFactoryTest.php
+++ b/test/ServerRequestFactoryTest.php
@@ -6,6 +6,7 @@ namespace LaminasTest\Diactoros;
 
 use Laminas\Diactoros\ServerRequest;
 use Laminas\Diactoros\ServerRequestFactory;
+use Laminas\Diactoros\ServerRequestFilter\DoNotFilter;
 use Laminas\Diactoros\ServerRequestFilter\FilterServerRequestInterface;
 use Laminas\Diactoros\UploadedFile;
 use Laminas\Diactoros\Uri;
@@ -751,5 +752,38 @@ class ServerRequestFactoryTest extends TestCase
         );
 
         $this->assertSame($expectedRequest, $request);
+    }
+
+    public function testHonorsHostHeaderOverServerNameWhenMarshalingUrl(): void
+    {
+        $server = [
+            'SERVER_NAME' => 'localhost',
+            'SERVER_PORT' => '80',
+            'SERVER_ADDR' => '172.22.0.4',
+            'REMOTE_PORT' => '36852',
+            'SERVER_PROTOCOL' => 'HTTP/1.1',
+            'DOCUMENT_ROOT' => '/var/www/public',
+            'DOCUMENT_URI' => '/index.php',
+            'REQUEST_URI' => '/api/messagebox-schema',
+            'PATH_TRANSLATED' => '/var/www/public',
+            'PATH_INFO' => '',
+            'SCRIPT_NAME' => '/index.php',
+            'REQUEST_METHOD' => 'GET',
+            'SCRIPT_FILENAME' => '/var/www/public/index.php',
+            // headers
+            'HTTP_HOST' => 'example.com',
+        ];
+
+        $request = ServerRequestFactory::fromGlobals(
+            $server,
+            null,
+            null,
+            null,
+            null,
+            new DoNotFilter()
+        );
+
+        $uri = $request->getUri();
+        $this->assertSame('example.com', $uri->getHost());
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

The patch introduced in 2.11.1 introduced 2 regressions:

- `FilterUsingXForwardedHeaders` was not filtering the `X-Forwarded-Proto` value before assigning it to the `Uri` instance, which could lead to exceptions when the value was not one of "http" or "https".
- `ServerRequestFactory::fromGlobals()` was no longer considering the `Host` header when resolving the host and port, which could lead to unexpected values for both items in the generated `Uri` instance.

This patch introduces tests to ensure the regressions do not occur in future releases, and patches to resolve them.
