### PR TITLE
Ignore obviously malformed `host` headers when constructing a ServerRequest

### DIFF
--- a/src/ServerRequestFactory.php
+++ b/src/ServerRequestFactory.php
@@ -289,9 +289,10 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
     /**
      * Retrieve a header value from an array of headers using a case-insensitive lookup.
      *
+     * @template T
      * @param array<string, string|list<string>> $headers Key/value header pairs
-     * @param mixed $default Default value to return if header not found
-     * @return mixed
+     * @param T $default Default value to return if header not found
+     * @return string|T
      */
     private static function getHeaderFromArray(string $name, array $headers, $default = null)
     {

--- a/test/ServerRequestFactoryTest.php
+++ b/test/ServerRequestFactoryTest.php
@@ -786,4 +786,40 @@ class ServerRequestFactoryTest extends TestCase
         $uri = $request->getUri();
         $this->assertSame('example.com', $uri->getHost());
     }
+
+    /**
+     * @psalm-return iterable<string, array{
+     *     0: string
+     * }>
+     */
+    public function invalidHostHeaders(): iterable
+    {
+        return [
+            'comma' => ['example.com,example.net'],
+            'space' => ['example com'],
+            'tab' => ["example\tcom"],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidHostHeaders
+     */
+    public function testRejectsDuplicatedHostHeader(string $host): void
+    {
+        $server = [
+            'HTTP_HOST' => $host,
+        ];
+
+        $request = ServerRequestFactory::fromGlobals(
+            $server,
+            null,
+            null,
+            null,
+            null,
+            new DoNotFilter()
+        );
+
+        $uri = $request->getUri();
+        $this->assertSame('', $uri->getHost());
+    }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

The comment within the code should be self-explanatory. This adds some very basic checks to the host header as a hardening measure.