### PR TITLE
Fixed `UploadedFile::moveTo()` so it actually removes the original file when used in CLI context, and doesn't leave orphaned files

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1164,54 +1164,10 @@
     </MissingReturnType>
   </file>
   <file src="test/UploadedFileTest.php">
-    <MissingParamType occurrences="6">
+    <MixedArgument occurrences="2">
       <code>$path</code>
-      <code>$status</code>
-      <code>$status</code>
-      <code>$status</code>
-      <code>$status</code>
-      <code>$streamOrFile</code>
-    </MissingParamType>
-    <MissingPropertyType occurrences="1">
-      <code>$tmpFile</code>
-    </MissingPropertyType>
-    <MissingReturnType occurrences="24">
-      <code>errorConstantsAndMessages</code>
-      <code>invalidErrorStatuses</code>
-      <code>invalidMovePaths</code>
-      <code>invalidStreams</code>
-      <code>nonOkErrorStatus</code>
-      <code>testCannotRetrieveStreamAfterMove</code>
-      <code>testConstructorDoesNotRaiseExceptionForInvalidStreamWhenErrorStatusPresent</code>
-      <code>testGetStreamRaisesExceptionWhenErrorStatusPresent</code>
-      <code>testGetStreamRaisesExceptionWithAppropriateMessageWhenUploadErrorDetected</code>
-      <code>testGetStreamReturnsOriginalStreamObject</code>
-      <code>testGetStreamReturnsStreamForFile</code>
-      <code>testGetStreamReturnsWrappedPhpStream</code>
-      <code>testMoveCannotBeCalledMoreThanOnce</code>
-      <code>testMoveRaisesExceptionForInvalidPath</code>
-      <code>testMoveToCreatesStreamIfOnlyAFilenameWasProvided</code>
-      <code>testMoveToRaisesExceptionWhenErrorStatusPresent</code>
-      <code>testMoveToRaisesExceptionWithAppropriateMessageWhenUploadErrorDetected</code>
-      <code>testMovesFileToDesignatedPath</code>
-      <code>testRaisesExceptionOnInvalidErrorStatus</code>
-      <code>testRaisesExceptionOnInvalidStreamOrFile</code>
-      <code>testValidClientFilename</code>
-      <code>testValidClientMediaType</code>
-      <code>testValidNullClientFilename</code>
-      <code>testValidSize</code>
-    </MissingReturnType>
-    <MixedArgument occurrences="6">
-      <code>$path</code>
-      <code>$status</code>
-      <code>$status</code>
-      <code>$status</code>
-      <code>$status</code>
       <code>$streamOrFile</code>
     </MixedArgument>
-    <UndefinedThisPropertyAssignment occurrences="1">
-      <code>$this-&gt;tmpfile</code>
-    </UndefinedThisPropertyAssignment>
   </file>
   <file src="test/UriTest.php">
     <InvalidScalarArgument occurrences="2">

--- a/src/UploadedFile.php
+++ b/src/UploadedFile.php
@@ -187,6 +187,13 @@ class UploadedFile implements UploadedFileInterface
             case (empty($sapi) || 0 === strpos($sapi, 'cli') || 0 === strpos($sapi, 'phpdbg') || ! $this->file):
                 // Non-SAPI environment, or no filename present
                 $this->writeFile($targetPath);
+
+                if ($this->stream instanceof StreamInterface) {
+                    $this->stream->close();
+                    if (is_string($this->file) && file_exists($this->file)) {
+                        unlink($this->file);
+                    }
+                }
                 break;
             default:
                 // SAPI environment, with file present

--- a/src/UploadedFile.php
+++ b/src/UploadedFile.php
@@ -190,9 +190,9 @@ class UploadedFile implements UploadedFileInterface
 
                 if ($this->stream instanceof StreamInterface) {
                     $this->stream->close();
-                    if (is_string($this->file) && file_exists($this->file)) {
-                        unlink($this->file);
-                    }
+                }
+                if (is_string($this->file) && file_exists($this->file)) {
+                    unlink($this->file);
                 }
                 break;
             default:


### PR DESCRIPTION
Signed-off-by: katsuren <katsuren.houken@gmail.com>
UploadedFile::moveTo doesn't work in CLI. Original file leave it as is.


|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Calling UploadedFile::moveTo in CLI, it just copies the file to the targetPath.
In addition to this, the stream grabs the original file, so it cannot delete the file, and I cannot access the stream so I couldn't release the file pointer.
In a test for uploading file, I want to remove the uploaded file to keep clean the test folder.
