### PR TITLE
Fix `symfony/error-handler` deprecations

### DIFF
--- a/src/CallbackStream.php
+++ b/src/CallbackStream.php
@@ -159,6 +159,7 @@ class CallbackStream implements StreamInterface
 
     /**
      * {@inheritdoc}
+     * @return mixed
      */
     public function getMetadata($key = null)
     {

--- a/src/RelativeStream.php
+++ b/src/RelativeStream.php
@@ -169,6 +169,7 @@ final class RelativeStream implements StreamInterface
 
     /**
      * {@inheritdoc}
+     * @return mixed
      */
     public function getMetadata($key = null)
     {

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -165,6 +165,7 @@ class ServerRequest implements ServerRequestInterface
 
     /**
      * {@inheritdoc}
+     * @return array|object|null
      */
     public function getParsedBody()
     {
@@ -199,6 +200,7 @@ class ServerRequest implements ServerRequestInterface
 
     /**
      * {@inheritdoc}
+     * @return mixed
      */
     public function getAttribute($attribute, $default = null)
     {

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -301,6 +301,7 @@ class Stream implements StreamInterface
 
     /**
      * {@inheritdoc}
+     * @return mixed
      */
     public function getMetadata($key = null)
     {


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes (?)
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

`symfony/error-handler` triggers deprecation errors in case of not (explicitly) specified return types when implemented interface have them declared (in phpdoc).
AFAIK they are triggered to make libraries migration to (possible) future declared return types more explicit.

It can be annoying to update all of libraries with such of changes, but these deprecation messages are pretty hard to silence :(

Here's log of there errors:
```
PHP Deprecated: Method "Psr\Http\Message\ServerRequestInterface::getParsedBody()" might add "array|object|null" as a native return type declaration in the future. Do the same in implementation "Laminas\Diactoros\ServerRequest" now to avoid errors or add an explicit @return annotation to suppress this message. in .../vendor/symfony/error-handler/DebugClassLoader.php on line 330
PHP Deprecated: Method "Psr\Http\Message\ServerRequestInterface::getAttribute()" might add "mixed" as a native return type declaration in the future. Do the same in implementation "Laminas\Diactoros\ServerRequest" now to avoid errors or add an explicit @return annotation to suppress this message. in .../vendor/symfony/error-handler/DebugClassLoader.php on line 330
PHP Deprecated: Method "Psr\Http\Message\StreamInterface::getMetadata()" might add "mixed" as a native return type declaration in the future. Do the same in implementation "Laminas\Diactoros\Stream" now to avoid errors or add an explicit @return annotation to suppress this message. in .../vendor/symfony/error-handler/DebugClassLoader.php on line 330
```

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
