### PR TITLE
Refined types as per `laminas/laminas-coding-standard:2.3.x` upgrades

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,9 @@
         "forum": "https://discourse.laminas.dev"
     },
     "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        },
         "sort-packages": true,
         "platform": {
             "php": "7.3.99"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -329,18 +329,9 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/functions/create_uploaded_file.legacy.php">
-    <InvalidReturnStatement occurrences="1">
-      <code>laminas_createUploadedFile(...func_get_args())</code>
-    </InvalidReturnStatement>
-    <InvalidReturnType occurrences="1">
-      <code>UploadedFile</code>
-    </InvalidReturnType>
     <MixedArgument occurrences="1">
       <code>func_get_args()</code>
     </MixedArgument>
-    <UndefinedClass occurrences="1">
-      <code>UploadedFile</code>
-    </UndefinedClass>
   </file>
   <file src="src/functions/create_uploaded_file.php">
     <MixedArgument occurrences="4">
@@ -386,18 +377,9 @@
     </MixedArgument>
   </file>
   <file src="src/functions/marshal_uri_from_sapi.legacy.php">
-    <InvalidReturnStatement occurrences="1">
-      <code>laminas_marshalUriFromSapi(...func_get_args())</code>
-    </InvalidReturnStatement>
-    <InvalidReturnType occurrences="1">
-      <code>Uri</code>
-    </InvalidReturnType>
     <MixedArgument occurrences="1">
       <code>func_get_args()</code>
     </MixedArgument>
-    <UndefinedClass occurrences="1">
-      <code>Uri</code>
-    </UndefinedClass>
   </file>
   <file src="src/functions/marshal_uri_from_sapi.php">
     <MissingClosureParamType occurrences="3">
@@ -529,19 +511,20 @@
     </MixedOperand>
   </file>
   <file src="test/RequestTest.php">
-    <DuplicateArrayKey occurrences="1">
-      <code>'UNLOCK'    =&gt; ['UNLOCK']</code>
-    </DuplicateArrayKey>
-  </file>
-  <file src="test/Response/XmlResponseTest.php">
-    <MissingReturnType occurrences="1">
-      <code>testRaisesExceptionforNonStringNonStreamBodyContent</code>
-    </MissingReturnType>
+    <MixedArgument occurrences="1">
+      <code>$headers</code>
+    </MixedArgument>
   </file>
   <file src="test/ResponseTest.php">
+    <LessSpecificReturnStatement occurrences="1">
+      <code>$ianaCodesReasonPhrases</code>
+    </LessSpecificReturnStatement>
     <MixedAssignment occurrences="1">
       <code>$responseCode</code>
     </MixedAssignment>
+    <MoreSpecificReturnType occurrences="1">
+      <code>list&lt;array{numeric-string, non-empty-string}&gt;</code>
+    </MoreSpecificReturnType>
     <RedundantConditionGivenDocblockType occurrences="1">
       <code>assertIsInt</code>
     </RedundantConditionGivenDocblockType>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -471,6 +471,14 @@
       <code>func_get_args()</code>
     </MixedArgument>
   </file>
+  <file src="src/functions/parse_cookie_header.php">
+    <LessSpecificReturnStatement occurrences="1">
+      <code>$cookies</code>
+    </LessSpecificReturnStatement>
+    <MoreSpecificReturnType occurrences="1">
+      <code>array&lt;non-empty-string, string&gt;</code>
+    </MoreSpecificReturnType>
+  </file>
   <file src="test/CallbackStreamTest.php">
     <MissingClosureReturnType occurrences="1">
       <code>function () {</code>

--- a/src/Exception/InvalidStreamPointerPositionException.php
+++ b/src/Exception/InvalidStreamPointerPositionException.php
@@ -9,10 +9,10 @@ use Throwable;
 
 class InvalidStreamPointerPositionException extends RuntimeException implements ExceptionInterface
 {
-    /** @param int $code */
+    /** {@inheritDoc} */
     public function __construct(
         string $message = 'Invalid pointer position',
-        $code = 0,
+        int $code = 0,
         ?Throwable $previous = null
     ) {
         parent::__construct($message, $code, $previous);

--- a/src/Exception/UploadedFileAlreadyMovedException.php
+++ b/src/Exception/UploadedFileAlreadyMovedException.php
@@ -9,10 +9,10 @@ use Throwable;
 
 class UploadedFileAlreadyMovedException extends RuntimeException implements ExceptionInterface
 {
-    /** @param int $code */
+    /** {@inheritDoc} */
     public function __construct(
         string $message = 'Cannot retrieve stream after it has already moved',
-        $code = 0,
+        int $code = 0,
         ?Throwable $previous = null
     ) {
         parent::__construct($message, $code, $previous);

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -303,9 +303,7 @@ trait MessageTrait
         return $new;
     }
 
-    /**
-     * @param StreamInterface|string|resource $stream
-     */
+    /** @param StreamInterface|string|resource $stream */
     private function getStream($stream, string $modeIfNotInstance): StreamInterface
     {
         if ($stream instanceof StreamInterface) {

--- a/src/Request/ArraySerializer.php
+++ b/src/Request/ArraySerializer.php
@@ -23,6 +23,15 @@ final class ArraySerializer
 {
     /**
      * Serialize a request message to an array.
+     *
+     * @return array{
+     *     method: string,
+     *     request_target: string,
+     *     uri: string,
+     *     protocol_version: string,
+     *     headers: array<array<string>>,
+     *     body: string
+     * }
      */
     public static function toArray(RequestInterface $request): array
     {

--- a/src/Response/ArraySerializer.php
+++ b/src/Response/ArraySerializer.php
@@ -23,6 +23,14 @@ final class ArraySerializer
 {
     /**
      * Serialize a response message to an array.
+     *
+     * @return array{
+     *     status_code: int,
+     *     reason_phrase: string,
+     *     protocol_version: string,
+     *     headers: array<array<string>>,
+     *     body: string
+     * }
      */
     public static function toArray(ResponseInterface $response): array
     {

--- a/src/functions/create_uploaded_file.legacy.php
+++ b/src/functions/create_uploaded_file.legacy.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Zend\Diactoros;
 
+use Laminas\Diactoros\UploadedFile;
+
 use function func_get_args;
 use function Laminas\Diactoros\createUploadedFile as laminas_createUploadedFile;
 

--- a/src/functions/marshal_uri_from_sapi.legacy.php
+++ b/src/functions/marshal_uri_from_sapi.legacy.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Zend\Diactoros;
 
+use Laminas\Diactoros\Uri;
+
 use function func_get_args;
 use function Laminas\Diactoros\marshalUriFromSapi as laminas_marshalUriFromSapi;
 

--- a/src/functions/parse_cookie_header.legacy.php
+++ b/src/functions/parse_cookie_header.legacy.php
@@ -11,7 +11,7 @@ use function Laminas\Diactoros\parseCookieHeader as laminas_parseCookieHeader;
  * @deprecated Use {@see \Laminas\Diactoros\parseCookieHeader} instead
  *
  * @param string $cookieHeader A string cookie header value.
- * @return array<string, string> key/value cookie pairs.
+ * @return array<non-empty-string, string> key/value cookie pairs.
  */
 function parseCookieHeader($cookieHeader): array
 {

--- a/src/functions/parse_cookie_header.legacy.php
+++ b/src/functions/parse_cookie_header.legacy.php
@@ -8,9 +8,10 @@ use function func_get_args;
 use function Laminas\Diactoros\parseCookieHeader as laminas_parseCookieHeader;
 
 /**
- * @deprecated Use \Laminas\Diactoros\parseCookieHeader instead
+ * @deprecated Use {@see \Laminas\Diactoros\parseCookieHeader} instead
  *
  * @param string $cookieHeader A string cookie header value.
+ * @return array<string, string> key/value cookie pairs.
  */
 function parseCookieHeader($cookieHeader): array
 {

--- a/src/functions/parse_cookie_header.php
+++ b/src/functions/parse_cookie_header.php
@@ -16,7 +16,7 @@ use const PREG_SET_ORDER;
  * overwriting. Thus, the server request should take the cookies from the request header instead.
  *
  * @param string $cookieHeader A string cookie header value.
- * @return array key/value cookie pairs.
+ * @return array<string, string> key/value cookie pairs.
  */
 function parseCookieHeader($cookieHeader): array
 {

--- a/src/functions/parse_cookie_header.php
+++ b/src/functions/parse_cookie_header.php
@@ -16,7 +16,7 @@ use const PREG_SET_ORDER;
  * overwriting. Thus, the server request should take the cookies from the request header instead.
  *
  * @param string $cookieHeader A string cookie header value.
- * @return array<string, string> key/value cookie pairs.
+ * @return array<non-empty-string, string> key/value cookie pairs.
  */
 function parseCookieHeader($cookieHeader): array
 {

--- a/test/CallbackStreamTest.php
+++ b/test/CallbackStreamTest.php
@@ -11,7 +11,7 @@ use RuntimeException;
 /**
  * @covers \Laminas\Diactoros\CallbackStream
  */
-class CallbackStreamTest extends TestCase
+final class CallbackStreamTest extends TestCase
 {
     public function testToString(): void
     {
@@ -173,7 +173,7 @@ class CallbackStreamTest extends TestCase
         $this->assertNull($notExists);
     }
 
-    /** @return array<string, array{0: callable, 1: string}> */
+    /** @return non-empty-array<non-empty-string, array{callable(): string, non-empty-string}> */
     public function phpCallbacksForStreams(): array
     {
         $class = TestAsset\CallbacksForCallbackStreamTest::class;
@@ -190,6 +190,8 @@ class CallbackStreamTest extends TestCase
 
     /**
      * @dataProvider phpCallbacksForStreams
+     * @param callable(): string $callback
+     * @param non-empty-string $expected
      */
     public function testAllowsArbitraryPhpCallbacks(callable $callback, string $expected): void
     {

--- a/test/HeaderSecurityTest.php
+++ b/test/HeaderSecurityTest.php
@@ -8,12 +8,12 @@ use InvalidArgumentException;
 use Laminas\Diactoros\HeaderSecurity;
 use PHPUnit\Framework\TestCase;
 
-class HeaderSecurityTest extends TestCase
+final class HeaderSecurityTest extends TestCase
 {
     /**
      * Data for filter value
      *
-     * @return array<int, array{0: string, 1: string}>
+     * @return non-empty-list<array{non-empty-string, non-empty-string}>
      */
     public function getFilterValues(): array
     {
@@ -34,42 +34,47 @@ class HeaderSecurityTest extends TestCase
 
     /**
      * @dataProvider getFilterValues
+     * @group ZF2015-04
+     * @param non-empty-string $value
+     * @param non-empty-string $expected
      */
     public function testFiltersValuesPerRfc7230(string $value, string $expected): void
     {
         $this->assertSame($expected, HeaderSecurity::filter($value));
     }
 
-    /** @return array<int, array{0: string, 1: string}> */
+    /** @return non-empty-list<array{non-empty-string, bool}> */
     public function validateValues(): array
     {
         return [
-            ["This is a\n test", 'assertFalse'],
-            ["This is a\r test", 'assertFalse'],
-            ["This is a\n\r test", 'assertFalse'],
-            ["This is a\r\n  test", 'assertTrue'],
-            ["This is a \r\ntest", 'assertFalse'],
-            ["This is a \r\n\n test", 'assertFalse'],
-            ["This is a\n\n test", 'assertFalse'],
-            ["This is a\r\r test", 'assertFalse'],
-            ["This is a \r\r\n test", 'assertFalse'],
-            ["This is a \r\n\r\ntest", 'assertFalse'],
-            ["This is a \r\n\n\r\n test", 'assertFalse'],
-            ["This is a \xFF test", 'assertFalse'],
-            ["This is a \x7F test", 'assertFalse'],
-            ["This is a \x7E test", 'assertTrue'],
+            ["This is a\n test", false],
+            ["This is a\r test", false],
+            ["This is a\n\r test", false],
+            ["This is a\r\n  test", true],
+            ["This is a \r\ntest", false],
+            ["This is a \r\n\n test", false],
+            ["This is a\n\n test", false],
+            ["This is a\r\r test", false],
+            ["This is a \r\r\n test", false],
+            ["This is a \r\n\r\ntest", false],
+            ["This is a \r\n\n\r\n test", false],
+            ["This is a \xFF test", false],
+            ["This is a \x7F test", false],
+            ["This is a \x7E test", true],
         ];
     }
 
     /**
      * @dataProvider validateValues
+     * @group ZF2015-04
+     * @param non-empty-string $value
      */
-    public function testValidatesValuesPerRfc7230(string $value, string $assertion): void
+    public function testValidatesValuesPerRfc7230(string $value, bool $expected): void
     {
-        $this->{$assertion}(HeaderSecurity::isValid($value));
+        self::assertSame($expected, HeaderSecurity::isValid($value));
     }
 
-    /** @return array<int, array{0: string}> */
+    /** @return non-empty-list<array{non-empty-string}> */
     public function assertValues(): array
     {
         return [
@@ -88,6 +93,8 @@ class HeaderSecurityTest extends TestCase
 
     /**
      * @dataProvider assertValues
+     * @group ZF2015-04
+     * @param non-empty-string $value
      */
     public function testAssertValidRaisesExceptionForInvalidValue(string $value): void
     {

--- a/test/Integration/RequestTest.php
+++ b/test/Integration/RequestTest.php
@@ -7,7 +7,7 @@ namespace LaminasTest\Diactoros\Integration;
 use Http\Psr7Test\RequestIntegrationTest;
 use Laminas\Diactoros\Request;
 
-class RequestTest extends RequestIntegrationTest
+final class RequestTest extends RequestIntegrationTest
 {
     public function createSubject(): Request
     {

--- a/test/Integration/ResponseTest.php
+++ b/test/Integration/ResponseTest.php
@@ -7,7 +7,7 @@ namespace LaminasTest\Diactoros\Integration;
 use Http\Psr7Test\ResponseIntegrationTest;
 use Laminas\Diactoros\Response;
 
-class ResponseTest extends ResponseIntegrationTest
+final class ResponseTest extends ResponseIntegrationTest
 {
     public function createSubject(): Response
     {

--- a/test/Integration/ServerRequestFactoryTest.php
+++ b/test/Integration/ServerRequestFactoryTest.php
@@ -8,7 +8,7 @@ use Http\Psr7Test\ServerRequestIntegrationTest;
 use Laminas\Diactoros\ServerRequestFactory;
 use Psr\Http\Message\ServerRequestInterface;
 
-class ServerRequestFactoryTest extends ServerRequestIntegrationTest
+final class ServerRequestFactoryTest extends ServerRequestIntegrationTest
 {
     public function createSubject(): ServerRequestInterface
     {

--- a/test/Integration/ServerRequestTest.php
+++ b/test/Integration/ServerRequestTest.php
@@ -7,7 +7,7 @@ namespace LaminasTest\Diactoros\Integration;
 use Http\Psr7Test\ServerRequestIntegrationTest;
 use Laminas\Diactoros\ServerRequest;
 
-class ServerRequestTest extends ServerRequestIntegrationTest
+final class ServerRequestTest extends ServerRequestIntegrationTest
 {
     public function createSubject(): ServerRequest
     {

--- a/test/Integration/StreamTest.php
+++ b/test/Integration/StreamTest.php
@@ -8,11 +8,9 @@ use Http\Psr7Test\StreamIntegrationTest;
 use Laminas\Diactoros\Stream;
 use Psr\Http\Message\StreamInterface;
 
-class StreamTest extends StreamIntegrationTest
+final class StreamTest extends StreamIntegrationTest
 {
-    /**
-     * @param string|resource|StreamInterface $data
-     */
+    /** {@inheritDoc} */
     public function createStream($data): StreamInterface
     {
         if ($data instanceof StreamInterface) {

--- a/test/Integration/UploadedFileTest.php
+++ b/test/Integration/UploadedFileTest.php
@@ -10,7 +10,7 @@ use Laminas\Diactoros\UploadedFile;
 
 use const UPLOAD_ERR_OK;
 
-class UploadedFileTest extends UploadedFileIntegrationTest
+final class UploadedFileTest extends UploadedFileIntegrationTest
 {
     public function createSubject(): UploadedFile
     {

--- a/test/Integration/UriTest.php
+++ b/test/Integration/UriTest.php
@@ -7,11 +7,9 @@ namespace LaminasTest\Diactoros\Integration;
 use Http\Psr7Test\UriIntegrationTest;
 use Laminas\Diactoros\Uri;
 
-class UriTest extends UriIntegrationTest
+final class UriTest extends UriIntegrationTest
 {
-    /**
-     * @param string $uri
-     */
+    /** {@inheritDoc} */
     public function createUri($uri): Uri
     {
         return new Uri($uri);

--- a/test/MessageTraitTest.php
+++ b/test/MessageTraitTest.php
@@ -422,6 +422,7 @@ class MessageTraitTest extends TestCase
 
     /**
      * @dataProvider invalidArrayHeaderValues
+     * @group 99
      * @param mixed $value
      */
     public function testWithHeaderShouldRaiseExceptionForInvalidHeaderValuesInArrays($value): void
@@ -435,6 +436,7 @@ class MessageTraitTest extends TestCase
 
     /**
      * @dataProvider invalidHeaderValueTypes
+     * @group 99
      * @param mixed $value
      */
     public function testWithHeaderShouldRaiseExceptionForInvalidHeaderScalarValues($value): void

--- a/test/PhpInputStreamTest.php
+++ b/test/PhpInputStreamTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 use function file_get_contents;
 use function substr;
 
-class PhpInputStreamTest extends TestCase
+final class PhpInputStreamTest extends TestCase
 {
     /** @var string */
     protected $file;

--- a/test/Request/SerializerTest.php
+++ b/test/Request/SerializerTest.php
@@ -65,7 +65,7 @@ class SerializerTest extends TestCase
         $this->assertStringContainsString("X-Foo-Bar: Bat", $message);
     }
 
-    /** @return array<string, array{0: string, 1: string, 2:array<string, string>}> */
+    /** @return non-empty-array<non-empty-string, array{non-empty-string, non-empty-string, array<non-empty-string, non-empty-string>}> */
     public function originForms(): array
     {
         return [
@@ -84,7 +84,9 @@ class SerializerTest extends TestCase
 
     /**
      * @dataProvider originForms
-     * @param array<string, string> $expectations
+     * @param non-empty-string                          $line
+     * @param non-empty-string                          $requestTarget
+     * @param array<non-empty-string, non-empty-string> $expectations
      */
     public function testCanDeserializeRequestWithOriginForm(
         string $line,
@@ -103,7 +105,23 @@ class SerializerTest extends TestCase
         }
     }
 
-    /** @return array<string, array{0: string, 1: string, 2:array<string, string|int>}> */
+    /**
+     * @return non-empty-array<
+     *     non-empty-string,
+     *     array{
+     *         non-empty-string,
+     *         non-empty-string,
+     *         array{
+     *             getScheme?: non-empty-string,
+     *             getUserInfo?: non-empty-string,
+     *             getHost?: non-empty-string,
+     *             getPort?: positive-int,
+     *             getPath?: non-empty-string,
+     *             getQuery?: non-empty-string
+     *         }
+     *     }
+     * >
+     */
     public function absoluteForms(): array
     {
         return [
@@ -152,15 +170,19 @@ class SerializerTest extends TestCase
         ];
     }
 
+    // @codingStandardsIgnoreStart if we split these line, phpcs can't associate parameter name and docblock anymore (phpcs limitation)
     /**
      * @dataProvider absoluteForms
-     * @param array<string, string|int> $expectations
+     * @param non-empty-string $line
+     * @param non-empty-string $requestTarget
+     * @param array{getScheme?: non-empty-string, getUserInfo?: non-empty-string, getHost?: non-empty-string, getPort?: positive-int, getPath?: non-empty-string, getQuery?: non-empty-string} $expectations
      */
     public function testCanDeserializeRequestWithAbsoluteForm(
         string $line,
         string $requestTarget,
         array $expectations
     ): void {
+        // @codingStandardsIgnoreEnd
         $message = $line . "\r\nX-Foo-Bar: Baz\r\n\r\nContent";
         $request = Serializer::fromString($message);
 
@@ -200,7 +222,7 @@ class SerializerTest extends TestCase
         $this->assertSame('www.example.com', $request->getHeaderLine('Host'));
     }
 
-    /** @return array<string, array{0: string}> */
+    /** @return non-empty-array<non-empty-string, array{non-empty-string}> */
     public function invalidRequestLines(): array
     {
         return [
@@ -213,6 +235,7 @@ class SerializerTest extends TestCase
 
     /**
      * @dataProvider invalidRequestLines
+     * @param non-empty-string $line
      */
     public function testRaisesExceptionDuringDeserializationForInvalidRequestLine(string $line): void
     {
@@ -236,7 +259,7 @@ class SerializerTest extends TestCase
         $this->assertSame(['Baz', 'Bat'], $values);
     }
 
-    /** @return array<string, array{0: string}> */
+    /** @return non-empty-array<non-empty-string, array{non-empty-string}> */
     public function headersWithContinuationLines(): array
     {
         return [
@@ -247,6 +270,7 @@ class SerializerTest extends TestCase
 
     /**
      * @dataProvider headersWithContinuationLines
+     * @param non-empty-string $text
      */
     public function testCanDeserializeRequestWithHeaderContinuations(string $text): void
     {
@@ -283,7 +307,7 @@ class SerializerTest extends TestCase
         $this->assertSame('Baz', $request->getHeaderLine('X-Foo-Bar'));
     }
 
-    /** @return array<string, array{0: string, 1: string}> */
+    /** @return non-empty-array<non-empty-string, array{non-empty-string, non-empty-string}> */
     public function messagesWithInvalidHeaders(): array
     {
         return [
@@ -304,6 +328,8 @@ class SerializerTest extends TestCase
 
     /**
      * @dataProvider messagesWithInvalidHeaders
+     * @param non-empty-string $message
+     * @param non-empty-string $exceptionMessage
      */
     public function testDeserializationRaisesExceptionForMalformedHeaders(
         string $message,

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\UriInterface;
 
-class RequestTest extends TestCase
+final class RequestTest extends TestCase
 {
     /** @var Request */
     protected $request;
@@ -34,8 +34,8 @@ class RequestTest extends TestCase
         $this->assertEquals('POST', $request->getMethod());
     }
 
-    /** @return array<int, array{0: mixed}> */
-    public function invalidMethod(): array
+    /** @return non-empty-list<array{mixed}> */
+    public function invalidMethod()
     {
         return [
             [null],
@@ -118,7 +118,7 @@ class RequestTest extends TestCase
         $this->assertSame("test", (string) $request->getBody());
     }
 
-    /** @return array<string, array{0: mixed}> */
+    /** @return non-empty-array<non-empty-string, array{mixed}> */
     public function invalidRequestUri(): array
     {
         return [
@@ -144,7 +144,7 @@ class RequestTest extends TestCase
         new Request($uri);
     }
 
-    /** @return array<string, array{0: string}> */
+    /** @return non-empty-array<non-empty-string, array{non-empty-string}> */
     public function invalidRequestMethod(): array
     {
         return [
@@ -154,6 +154,7 @@ class RequestTest extends TestCase
 
     /**
      * @dataProvider invalidRequestMethod
+     * @param non-empty-string $method
      */
     public function testConstructorRaisesExceptionForInvalidMethod(string $method): void
     {
@@ -163,7 +164,7 @@ class RequestTest extends TestCase
         new Request(null, $method);
     }
 
-    /** @return array<string, array{0: string}> */
+    /** @return non-empty-array<non-empty-string, array{non-empty-string}> */
     public function customRequestMethods(): array
     {
         return [
@@ -176,7 +177,6 @@ class RequestTest extends TestCase
             'MOVE'      => ['MOVE'],
             'LOCK'      => ['LOCK'],
             'UNLOCK'    => ['UNLOCK'],
-            'UNLOCK'    => ['UNLOCK'],
             /* Arbitrary methods */
             '#!ALPHA-1234&%' => ['#!ALPHA-1234&%'],
         ];
@@ -184,6 +184,8 @@ class RequestTest extends TestCase
 
     /**
      * @dataProvider customRequestMethods
+     * @group 29
+     * @param non-empty-string $method
      */
     public function testAllowsCustomRequestMethodsThatFollowSpec(string $method): void
     {
@@ -191,7 +193,7 @@ class RequestTest extends TestCase
         $this->assertSame($method, $request->getMethod());
     }
 
-    /** @return array<string, array{0: mixed}> */
+    /** @return non-empty-array<non-empty-string, array{mixed}> */
     public function invalidRequestBody(): array
     {
         return [
@@ -217,7 +219,7 @@ class RequestTest extends TestCase
         new Request(null, null, $body);
     }
 
-    /** @return array<string, array{0: mixed[], 1?: string}> */
+    /** @return non-empty-array<non-empty-string, array{0: mixed, 1?: non-empty-string}> */
     public function invalidHeaderTypes(): array
     {
         return [
@@ -231,10 +233,12 @@ class RequestTest extends TestCase
 
     /**
      * @dataProvider invalidHeaderTypes
-     * @param mixed[] $headers
+     * @group 99
+     * @param mixed $headers
+     * @param non-empty-string $contains
      */
     public function testConstructorRaisesExceptionForInvalidHeaders(
-        array $headers,
+        $headers,
         string $contains = 'header value type'
     ): void {
         $this->expectException(InvalidArgumentException::class);
@@ -256,7 +260,7 @@ class RequestTest extends TestCase
         $this->assertSame('/', $request->getRequestTarget());
     }
 
-    /** @return array<string, array{0: RequestInterface, 1: string}> */
+    /** @return non-empty-array<non-empty-string, array{RequestInterface, non-empty-string}> */
     public function requestsWithUri(): array
     {
         return [
@@ -289,13 +293,14 @@ class RequestTest extends TestCase
 
     /**
      * @dataProvider requestsWithUri
+     * @param non-empty-string $expected
      */
     public function testReturnsRequestTargetWhenUriIsPresent(RequestInterface $request, string $expected): void
     {
         $this->assertSame($expected, $request->getRequestTarget());
     }
 
-    /** @return array<string, array{0:string}> */
+    /** @return non-empty-array<non-empty-string, array{non-empty-string}> */
     public function validRequestTargets(): array
     {
         return [
@@ -310,6 +315,7 @@ class RequestTest extends TestCase
 
     /**
      * @dataProvider validRequestTargets
+     * @param non-empty-string $requestTarget
      */
     public function testCanProvideARequestTarget(string $requestTarget): void
     {
@@ -343,6 +349,9 @@ class RequestTest extends TestCase
         $this->assertNotSame($request->getRequestTarget(), $newRequest->getRequestTarget());
     }
 
+    /**
+     * @group 39
+     */
     public function testGetHeadersContainsHostHeaderIfUriWithHostIsPresent(): void
     {
         $request = new Request('http://example.com');
@@ -351,6 +360,9 @@ class RequestTest extends TestCase
         $this->assertStringContainsString('example.com', $headers['Host'][0]);
     }
 
+    /**
+     * @group 39
+     */
     public function testGetHeadersContainsHostHeaderIfUriWithHostIsDeleted(): void
     {
         $request = (new Request('http://example.com'))->withoutHeader('host');
@@ -359,6 +371,9 @@ class RequestTest extends TestCase
         $this->assertContains('example.com', $headers['Host']);
     }
 
+    /**
+     * @group 39
+     */
     public function testGetHeadersContainsNoHostHeaderIfNoUriPresent(): void
     {
         $request = new Request();
@@ -366,6 +381,9 @@ class RequestTest extends TestCase
         $this->assertArrayNotHasKey('Host', $headers);
     }
 
+    /**
+     * @group 39
+     */
     public function testGetHeadersContainsNoHostHeaderIfUriDoesNotContainHost(): void
     {
         $request = new Request(new Uri());
@@ -373,6 +391,9 @@ class RequestTest extends TestCase
         $this->assertArrayNotHasKey('Host', $headers);
     }
 
+    /**
+     * @group 39
+     */
     public function testGetHostHeaderReturnsUriHostWhenPresent(): void
     {
         $request = new Request('http://example.com');
@@ -380,6 +401,9 @@ class RequestTest extends TestCase
         $this->assertSame(['example.com'], $header);
     }
 
+    /**
+     * @group 39
+     */
     public function testGetHostHeaderReturnsUriHostWhenHostHeaderDeleted(): void
     {
         $request = (new Request('http://example.com'))->withoutHeader('host');
@@ -387,18 +411,27 @@ class RequestTest extends TestCase
         $this->assertSame(['example.com'], $header);
     }
 
+    /**
+     * @group 39
+     */
     public function testGetHostHeaderReturnsEmptyArrayIfNoUriPresent(): void
     {
         $request = new Request();
         $this->assertSame([], $request->getHeader('host'));
     }
 
+    /**
+     * @group 39
+     */
     public function testGetHostHeaderReturnsEmptyArrayIfUriDoesNotContainHost(): void
     {
         $request = new Request(new Uri());
         $this->assertSame([], $request->getHeader('host'));
     }
 
+    /**
+     * @group 39
+     */
     public function testGetHostHeaderLineReturnsUriHostWhenPresent(): void
     {
         $request = new Request('http://example.com');
@@ -406,12 +439,18 @@ class RequestTest extends TestCase
         $this->assertStringContainsString('example.com', $header);
     }
 
+    /**
+     * @group 39
+     */
     public function testGetHostHeaderLineReturnsEmptyStringIfNoUriPresent(): void
     {
         $request = new Request();
         $this->assertEmpty($request->getHeaderLine('host'));
     }
 
+    /**
+     * @group 39
+     */
     public function testGetHostHeaderLineReturnsEmptyStringIfUriDoesNotContainHost(): void
     {
         $request = new Request(new Uri());
@@ -466,7 +505,7 @@ class RequestTest extends TestCase
         $this->assertSame('www.example.com:10081', $new->getHeaderLine('Host'));
     }
 
-    /** @return array<string, array{0: string, 1: string|list<string>}> */
+    /** @return non-empty-array<non-empty-string, array{non-empty-string, non-empty-string|array{non-empty-string}}> */
     public function headersWithInjectionVectors(): array
     {
         return [
@@ -487,7 +526,8 @@ class RequestTest extends TestCase
 
     /**
      * @dataProvider headersWithInjectionVectors
-     * @param string|list<string> $value
+     * @param non-empty-string $name
+     * @param non-empty-string|array{non-empty-string} $value
      */
     public function testConstructorRaisesExceptionForHeadersWithCRLFVectors(string $name, $value): void
     {
@@ -496,7 +536,7 @@ class RequestTest extends TestCase
         new Request(null, null, 'php://memory', [$name => $value]);
     }
 
-    /** @return array<string, array{0: string}> */
+    /** @return non-empty-array<non-empty-string, array{non-empty-string}> */
     public function hostHeaderKeys(): array
     {
         return [
@@ -521,6 +561,7 @@ class RequestTest extends TestCase
 
     /**
      * @dataProvider hostHeaderKeys
+     * @param non-empty-string $hostKey
      */
     public function testWithUriAndNoPreserveHostWillOverwriteHostHeaderRegardlessOfOriginalCase(string $hostKey): void
     {

--- a/test/Response/ArraySerializerTest.php
+++ b/test/Response/ArraySerializerTest.php
@@ -56,6 +56,15 @@ class ArraySerializerTest extends TestCase
             ->withBody($stream);
     }
 
+    /**
+     * @return array{
+     *     status_code: positive-int,
+     *     reason_phrase: non-empty-string,
+     *     protocol_version: non-empty-string,
+     *     headers: array<non-empty-string, non-empty-list<string>>,
+     *     body: string,
+     * }
+     */
     private function createSerializedResponse(): array
     {
         return [

--- a/test/Response/HtmlResponseTest.php
+++ b/test/Response/HtmlResponseTest.php
@@ -56,7 +56,7 @@ class HtmlResponseTest extends TestCase
         $this->assertSame($body, $response->getBody());
     }
 
-    /** @return array<string, array{0: mixed}> */
+    /** @return array<non-empty-string, array{mixed}> */
     public function invalidHtmlContent(): array
     {
         return [

--- a/test/Response/JsonResponseTest.php
+++ b/test/Response/JsonResponseTest.php
@@ -40,7 +40,7 @@ class JsonResponseTest extends TestCase
         $this->assertSame($json, (string) $response->getBody());
     }
 
-    /** @return array<string, array{0: mixed}> */
+    /** @return non-empty-array<non-empty-string, array{mixed}> */
     public function scalarValuesForJSON()
     {
         return [
@@ -104,7 +104,7 @@ class JsonResponseTest extends TestCase
         new JsonResponse($data);
     }
 
-    /** @return array<string, array{0: string, 1: string}> */
+    /** @return non-empty-array<non-empty-string, array{non-empty-string, non-empty-string}> */
     public function valuesToJsonEncode(): array
     {
         return [
@@ -116,6 +116,8 @@ class JsonResponseTest extends TestCase
 
     /**
      * @dataProvider valuesToJsonEncode
+     * @param non-empty-string $value
+     * @param non-empty-string $key
      */
     public function testUsesSaneDefaultJsonEncodingFlags(string $value, string $key): void
     {

--- a/test/Response/RedirectResponseTest.php
+++ b/test/Response/RedirectResponseTest.php
@@ -46,7 +46,7 @@ class RedirectResponseTest extends TestCase
         $this->assertSame('Bar', $response->getHeaderLine('X-Foo'));
     }
 
-    /** @return array<string, array{0: mixed}> */
+    /** @return non-empty-array<non-empty-string, array{mixed}> */
     public function invalidUris(): array
     {
         return [

--- a/test/Response/SerializerTest.php
+++ b/test/Response/SerializerTest.php
@@ -12,7 +12,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 use UnexpectedValueException;
 
-class SerializerTest extends TestCase
+final class SerializerTest extends TestCase
 {
     public function testSerializesBasicResponse(): void
     {
@@ -99,7 +99,7 @@ class SerializerTest extends TestCase
         $this->assertSame(['Baz', 'Bat'], $values);
     }
 
-    /** @return array<string, array{0: string}> */
+    /** @return non-empty-array<non-empty-string, array{non-empty-string}> */
     public function headersWithContinuationLines(): array
     {
         return [
@@ -110,6 +110,7 @@ class SerializerTest extends TestCase
 
     /**
      * @dataProvider headersWithContinuationLines
+     * @param non-empty-string $text
      */
     public function testCanDeserializeResponseWithHeaderContinuations(string $text): void
     {
@@ -197,7 +198,7 @@ class SerializerTest extends TestCase
         Serializer::fromString($text);
     }
 
-    /** @return array<string, array{0: string, 1: string}> */
+    /** @return non-empty-array<non-empty-string, array{non-empty-string, non-empty-string}> */
     public function messagesWithInvalidHeaders(): array
     {
         return [
@@ -218,6 +219,8 @@ class SerializerTest extends TestCase
 
     /**
      * @dataProvider messagesWithInvalidHeaders
+     * @param non-empty-string $message
+     * @param non-empty-string $exceptionMessage
      */
     public function testDeserializationRaisesExceptionForMalformedHeaders(
         string $message,
@@ -259,6 +262,9 @@ class SerializerTest extends TestCase
         Serializer::fromStream($stream);
     }
 
+    /**
+     * @group 113
+     */
     public function testDeserializeCorrectlyCastsStatusCodeToInteger(): void
     {
         $response = Response\Serializer::fromString('HTTP/1.0 204');

--- a/test/Response/TextResponseTest.php
+++ b/test/Response/TextResponseTest.php
@@ -7,13 +7,10 @@ namespace LaminasTest\Diactoros\Response;
 use InvalidArgumentException;
 use Laminas\Diactoros\Response\TextResponse;
 use PHPUnit\Framework\TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Message\StreamInterface;
 
 class TextResponseTest extends TestCase
 {
-    use ProphecyTrait;
-
     public function testConstructorAcceptsBodyAsString(): void
     {
         $body = 'Uh oh not found';
@@ -50,13 +47,12 @@ class TextResponseTest extends TestCase
 
     public function testAllowsStreamsForResponseBody(): void
     {
-        $stream   = $this->prophesize(StreamInterface::class);
-        $body     = $stream->reveal();
+        $body     = $this->createMock(StreamInterface::class);
         $response = new TextResponse($body);
         $this->assertSame($body, $response->getBody());
     }
 
-    /** @return array<string, array{0: mixed}> */
+    /** @return non-empty-array<non-empty-string, array{mixed}> */
     public function invalidContent(): array
     {
         return [
@@ -84,6 +80,9 @@ class TextResponseTest extends TestCase
         new TextResponse($body);
     }
 
+    /**
+     * @group 115
+     */
     public function testConstructorRewindsBodyStream(): void
     {
         $text     = 'test data';

--- a/test/Response/XmlResponseTest.php
+++ b/test/Response/XmlResponseTest.php
@@ -7,15 +7,12 @@ namespace LaminasTest\Diactoros\Response;
 use InvalidArgumentException;
 use Laminas\Diactoros\Response\XmlResponse;
 use PHPUnit\Framework\TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Message\StreamInterface;
 
 use const PHP_EOL;
 
 class XmlResponseTest extends TestCase
 {
-    use ProphecyTrait;
-
     public function testConstructorAcceptsBodyAsString(): void
     {
         $body = 'Super valid XML';
@@ -52,13 +49,12 @@ class XmlResponseTest extends TestCase
 
     public function testAllowsStreamsForResponseBody(): void
     {
-        $stream   = $this->prophesize(StreamInterface::class);
-        $body     = $stream->reveal();
+        $body     = $this->createMock(StreamInterface::class);
         $response = new XmlResponse($body);
         $this->assertSame($body, $response->getBody());
     }
 
-    /** @return array<string, array{0: mixed}> */
+    /** @return non-empty-array<non-empty-string, array{mixed}> */
     public function invalidContent(): array
     {
         return [
@@ -78,7 +74,7 @@ class XmlResponseTest extends TestCase
      * @dataProvider invalidContent
      * @param mixed $body
      */
-    public function testRaisesExceptionforNonStringNonStreamBodyContent($body)
+    public function testRaisesExceptionforNonStringNonStreamBodyContent($body): void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -86,6 +82,9 @@ class XmlResponseTest extends TestCase
         new XmlResponse($body);
     }
 
+    /**
+     * @group 115
+     */
     public function testConstructorRewindsBodyStream(): void
     {
         $body     = '<?xml version="1.0"?>' . PHP_EOL . '<something>Valid XML</something>';

--- a/test/ResponseTest.php
+++ b/test/ResponseTest.php
@@ -33,7 +33,7 @@ use const CURLOPT_TIMEOUT;
 use const CURLOPT_USERAGENT;
 use const LOCK_EX;
 
-class ResponseTest extends TestCase
+final class ResponseTest extends TestCase
 {
     /** @var Response */
     protected $response;
@@ -119,7 +119,7 @@ class ResponseTest extends TestCase
         self::fail('Unable to retrieve IANA response status codes due to timeout or invalid XML');
     }
 
-    /** @return list<array{string, string}> */
+    /** @return list<array{numeric-string, non-empty-string}> */
     public function ianaCodesReasonPhrasesProvider(): array
     {
         $ianaHttpStatusCodes = $this->fetchIanaStatusCodes();
@@ -153,9 +153,10 @@ class ResponseTest extends TestCase
 
     /**
      * @dataProvider ianaCodesReasonPhrasesProvider
-     * @param string|numeric $code
+     * @param numeric-string $code
+     * @param non-empty-string $reasonPhrase
      */
-    public function testReasonPhraseDefaultsAgainstIana($code, string $reasonPhrase): void
+    public function testReasonPhraseDefaultsAgainstIana(string $code, string $reasonPhrase): void
     {
         /** @psalm-suppress InvalidScalarArgument */
         $response = $this->response->withStatus($code);
@@ -168,7 +169,7 @@ class ResponseTest extends TestCase
         $this->assertSame('Foo Bar!', $response->getReasonPhrase());
     }
 
-    /** @return array<string, array{0: mixed}> */
+    /** @return non-empty-array<non-empty-string, array{mixed}> */
     public function invalidReasonPhrases(): array
     {
         return [
@@ -218,7 +219,7 @@ class ResponseTest extends TestCase
 
     /**
      * @dataProvider validStatusCodes
-     * @param numeric $code
+     * @param int|numeric-string $code
      */
     public function testCreateWithValidStatusCodes($code): void
     {
@@ -231,7 +232,7 @@ class ResponseTest extends TestCase
         $this->assertIsInt($result);
     }
 
-    /** @return array<string, array{0: numeric}> */
+    /** @return non-empty-array<non-empty-string, array{int|numeric-string}> */
     public function validStatusCodes(): array
     {
         return [
@@ -254,7 +255,7 @@ class ResponseTest extends TestCase
         $this->response->withStatus($code);
     }
 
-    /** @return array<string, array{0: mixed}> */
+    /** @return non-empty-array<non-empty-string, array{mixed}> */
     public function invalidStatusCodes(): array
     {
         return [
@@ -270,7 +271,7 @@ class ResponseTest extends TestCase
         ];
     }
 
-    /** @return array<string, array{0: mixed}> */
+    /** @return non-empty-array<non-empty-string, array{mixed}> */
     public function invalidResponseBody(): array
     {
         return [
@@ -296,7 +297,7 @@ class ResponseTest extends TestCase
         new Response($body);
     }
 
-    /** @return array<string, array{0: array, 1?: string}> */
+    /** @return non-empty-array<non-empty-string, array{0: array<mixed>, 1?: non-empty-string}> */
     public function invalidHeaderTypes(): array
     {
         return [
@@ -310,6 +311,9 @@ class ResponseTest extends TestCase
 
     /**
      * @dataProvider invalidHeaderTypes
+     * @group 99
+     * @param array<mixed> $headers
+     * @param non-empty-string $contains
      */
     public function testConstructorRaisesExceptionForInvalidHeaders(
         array $headers,
@@ -328,7 +332,7 @@ class ResponseTest extends TestCase
         $this->assertEmpty($response->getReasonPhrase());
     }
 
-    /** @return array<string, array{0: string, 1: string|list<string>}> */
+    /** @return non-empty-array<non-empty-string, array{non-empty-string, non-empty-string|non-empty-list<non-empty-string>}> */
     public function headersWithInjectionVectors(): array
     {
         return [
@@ -348,8 +352,8 @@ class ResponseTest extends TestCase
     }
 
     /**
-     * @param string|list<string> $value
      * @dataProvider headersWithInjectionVectors
+     * @param string|non-empty-list<non-empty-string> $value
      */
     public function testConstructorRaisesExceptionForHeadersWithCRLFVectors(string $name, $value): void
     {

--- a/test/ServerRequestFactoryTest.php
+++ b/test/ServerRequestFactoryTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace LaminasTest\Diactoros;
 
-use Generator;
 use Laminas\Diactoros\ServerRequest;
 use Laminas\Diactoros\ServerRequestFactory;
 use Laminas\Diactoros\ServerRequestFilter\DoNotFilter;
@@ -26,7 +25,7 @@ use function str_replace;
 use function strpos;
 use function strtolower;
 
-class ServerRequestFactoryTest extends TestCase
+final class ServerRequestFactoryTest extends TestCase
 {
     public function testReturnsServerValueUnchangedIfHttpAuthorizationHeaderIsPresent(): void
     {
@@ -255,9 +254,7 @@ class ServerRequestFactoryTest extends TestCase
         $this->assertNull($uri->getPort());
     }
 
-    /**
-     * @return array<string, array{0: string}>
-     */
+    /** @return non-empty-array<non-empty-string, array{non-empty-string}> */
     public function httpsParamProvider(): array
     {
         return [
@@ -268,6 +265,7 @@ class ServerRequestFactoryTest extends TestCase
 
     /**
      * @dataProvider httpsParamProvider
+     * @param non-empty-string $param
      */
     public function testMarshalUriDetectsHttpsSchemeFromServerValue(string $param): void
     {
@@ -285,10 +283,8 @@ class ServerRequestFactoryTest extends TestCase
         $this->assertSame('https', $uri->getScheme());
     }
 
-    /**
-     * @return Generator<string, array{0: string, 1: string}>
-     */
-    public function httpsDisableParamProvider(): Generator
+    /** @return iterable<string, array{non-empty-string, 'off'|'OFF'}> */
+    public function httpsDisableParamProvider(): iterable
     {
         foreach ($this->httpsParamProvider() as $key => $data) {
             $param = array_shift($data);
@@ -302,6 +298,8 @@ class ServerRequestFactoryTest extends TestCase
 
     /**
      * @dataProvider httpsDisableParamProvider
+     * @param non-empty-string $param
+     * @param 'off'|'OFF' $value
      */
     public function testMarshalUriUsesHttpSchemeIfHttpsServerValueEqualsOff(string $param, string $value): void
     {
@@ -321,6 +319,7 @@ class ServerRequestFactoryTest extends TestCase
 
     /**
      * @dataProvider httpsParamProvider
+     * @param non-empty-string $xForwardedProto
      */
     public function testMarshalUriDetectsHttpsSchemeFromXForwardedProtoValue(string $xForwardedProto): void
     {
@@ -481,7 +480,7 @@ class ServerRequestFactoryTest extends TestCase
         $this->assertSame(['foo_bar' => 'bat'], $request->getCookieParams());
     }
 
-    /** @return array<string, array{0: string, 1: array}> */
+    /** @return non-empty-array<non-empty-string, array{non-empty-string, array<non-empty-string, non-empty-string>}> */
     public function cookieHeaderValues(): array
     {
         return [
@@ -514,7 +513,8 @@ class ServerRequestFactoryTest extends TestCase
 
     /**
      * @dataProvider cookieHeaderValues
-     * @param array $expectedCookies
+     * @param non-empty-string $cookieHeader
+     * @param array<non-empty-string, non-empty-string> $expectedCookies
      */
     public function testCookieHeaderVariations(string $cookieHeader, array $expectedCookies): void
     {
@@ -555,6 +555,10 @@ class ServerRequestFactoryTest extends TestCase
         $this->assertSame($expected, $server);
     }
 
+    /**
+     * @group 57
+     * @group 56
+     */
     public function testNormalizeFilesReturnsOnlyActualFilesWhenOriginalFilesContainsNestedAssociativeArrays(): void
     {
         $files = [
@@ -586,6 +590,8 @@ class ServerRequestFactoryTest extends TestCase
 
     /**
      * @dataProvider marshalProtocolVersionProvider
+     * @param non-empty-string $protocol
+     * @param non-empty-string $expected
      */
     public function testMarshalProtocolVersionReturnsHttpVersions(string $protocol, string $expected): void
     {
@@ -593,7 +599,7 @@ class ServerRequestFactoryTest extends TestCase
         $this->assertSame($expected, $version);
     }
 
-    /** @return array<string, array{0: string, 1: string}> */
+    /** @return non-empty-array<non-empty-string, array{non-empty-string, non-empty-string}> */
     public function marshalProtocolVersionProvider(): array
     {
         return [

--- a/test/ServerRequestTest.php
+++ b/test/ServerRequestTest.php
@@ -11,7 +11,7 @@ use Laminas\Diactoros\Uri;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 
-class ServerRequestTest extends TestCase
+final class ServerRequestTest extends TestCase
 {
     /** @var ServerRequest */
     protected $request;
@@ -101,7 +101,7 @@ class ServerRequestTest extends TestCase
         $this->assertNull($new->getAttribute('foo', null));
     }
 
-    /** @return array<string, array{0: string|null, 1: string}> */
+    /** @return non-empty-array<non-empty-string, array{non-empty-string|null, non-empty-string}> */
     public function provideMethods(): array
     {
         return [
@@ -113,6 +113,8 @@ class ServerRequestTest extends TestCase
 
     /**
      * @dataProvider provideMethods
+     * @param non-empty-string|null $parameterMethod
+     * @param non-empty-string $methodReturned
      */
     public function testUsesProvidedConstructorArguments(?string $parameterMethod, string $methodReturned): void
     {
@@ -171,6 +173,9 @@ class ServerRequestTest extends TestCase
         $this->assertSame('php://memory', $stream);
     }
 
+    /**
+     * @group 46
+     */
     public function testCookieParamsAreAnEmptyArrayAtInitialization(): void
     {
         $request = new ServerRequest();
@@ -178,6 +183,9 @@ class ServerRequestTest extends TestCase
         $this->assertCount(0, $request->getCookieParams());
     }
 
+    /**
+     * @group 46
+     */
     public function testQueryParamsAreAnEmptyArrayAtInitialization(): void
     {
         $request = new ServerRequest();
@@ -185,6 +193,9 @@ class ServerRequestTest extends TestCase
         $this->assertCount(0, $request->getQueryParams());
     }
 
+    /**
+     * @group 46
+     */
     public function testParsedBodyIsNullAtInitialization(): void
     {
         $request = new ServerRequest();

--- a/test/StreamTest.php
+++ b/test/StreamTest.php
@@ -32,10 +32,10 @@ use function unlink;
 
 use const DIRECTORY_SEPARATOR;
 
-class StreamTest extends TestCase
+final class StreamTest extends TestCase
 {
-    /** @var string|null */
-    public $tmpnam;
+    /** @var string|null|false */
+    private $tmpnam;
 
     /** @var Stream */
     protected $stream;
@@ -146,6 +146,9 @@ class StreamTest extends TestCase
         $this->assertSame($resource, $detached);
     }
 
+    /**
+     * @group 42
+     */
     public function testSizeReportsNullWhenNoResourcePresent(): void
     {
         $this->stream->detach();
@@ -286,7 +289,7 @@ class StreamTest extends TestCase
         $this->assertTrue($stream->isWritable());
     }
 
-    /** @return array<int, array{0: string, 1: bool, 2: bool}> */
+    /** @return non-empty-list<array{non-empty-string, bool, bool}> */
     public function provideDataForIsWritable(): array
     {
         return [
@@ -316,17 +319,16 @@ class StreamTest extends TestCase
 
     private function findNonExistentTempName(): string
     {
-        while (true) {
+        do {
             $tmpnam = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'diac' . uniqid();
-            if (! file_exists(sys_get_temp_dir() . $tmpnam)) {
-                break;
-            }
-        }
+        } while (file_exists(sys_get_temp_dir() . $tmpnam));
+
         return $tmpnam;
     }
 
     /**
      * @dataProvider provideDataForIsWritable
+     * @param non-empty-string $mode
      */
     public function testIsWritableReturnsCorrectFlagForMode(string $mode, bool $fileShouldExist, bool $flag): void
     {
@@ -342,7 +344,7 @@ class StreamTest extends TestCase
         $this->assertSame($flag, $stream->isWritable());
     }
 
-    /** @return array<int, array{0: string, 1: bool, 2: bool}> */
+    /** @return non-empty-list<array{non-empty-string, bool, bool}> */
     public function provideDataForIsReadable(): array
     {
         return [
@@ -372,6 +374,7 @@ class StreamTest extends TestCase
 
     /**
      * @dataProvider provideDataForIsReadable
+     * @param non-empty-string $mode
      */
     public function testIsReadableReturnsCorrectFlagForMode(string $mode, bool $fileShouldExist, bool $flag): void
     {
@@ -460,7 +463,7 @@ class StreamTest extends TestCase
         $stream->getContents();
     }
 
-    /** @return array<string, array{0: mixed}> */
+    /** @return non-empty-array<non-empty-string, array{mixed}> */
     public function invalidResources(): array
     {
         $this->tmpnam = tempnam(sys_get_temp_dir(), 'diac');
@@ -584,6 +587,9 @@ class StreamTest extends TestCase
         $this->assertNull($this->stream->getMetadata('TOTALLY_MADE_UP'));
     }
 
+    /**
+     * @group 42
+     */
     public function testGetSizeReturnsStreamSize(): void
     {
         $resource = fopen(__FILE__, 'r');
@@ -592,6 +598,9 @@ class StreamTest extends TestCase
         $this->assertSame($expected['size'], $stream->getSize());
     }
 
+    /**
+     * @group 67
+     */
     public function testRaisesExceptionOnConstructionForNonStreamResources(): void
     {
         $resource = $this->getResourceFor67();
@@ -606,6 +615,9 @@ class StreamTest extends TestCase
         new Stream($resource);
     }
 
+    /**
+     * @group 67
+     */
     public function testRaisesExceptionOnAttachForNonStreamResources(): void
     {
         $resource = $this->getResourceFor67();
@@ -657,6 +669,9 @@ class StreamTest extends TestCase
         $this->assertSame('FOO BAR', $stream->__toString());
     }
 
+    /**
+     * @group 42
+     */
     public function testSizeReportsNullForPhpInputStreams(): void
     {
         $resource = fopen('php://input', 'r');

--- a/test/UriTest.php
+++ b/test/UriTest.php
@@ -87,7 +87,7 @@ class UriTest extends TestCase
         $this->assertSame('https://user:pass@local.example.com:3001/foo?bar=baz#quz', (string) $new);
     }
 
-    /** @return array<string, array{0: string, 1: string, 2: string}> */
+    /** @return non-empty-array<non-empty-string, array{non-empty-string, non-empty-string, non-empty-string}> */
     public function userInfoProvider(): array
     {
         // @codingStandardsIgnoreStart
@@ -105,6 +105,9 @@ class UriTest extends TestCase
 
     /**
      * @dataProvider userInfoProvider
+     * @param non-empty-string $user
+     * @param non-empty-string $credential
+     * @param non-empty-string $expected
      */
     public function testWithUserInfoEncodesUsernameAndPassword(string $user, string $credential, string $expected): void
     {
@@ -132,7 +135,7 @@ class UriTest extends TestCase
         $this->assertSame('https://user:pass@local.example.com:3001/foo?bar=baz#quz', (string) $new);
     }
 
-    /** @return array<string, array{0: numeric|null}> */
+    /** @return non-empty-array<non-empty-string, array{null|positive-int|numeric-string}> */
     public function validPorts(): array
     {
         return [
@@ -144,7 +147,7 @@ class UriTest extends TestCase
 
     /**
      * @dataProvider validPorts
-     * @param numeric|null $port
+     * @param null|positive-int|numeric-string $port
      */
     public function testWithPortReturnsNewInstanceWithProvidedPort($port): void
     {
@@ -168,7 +171,7 @@ class UriTest extends TestCase
         $this->assertSame(3001, $new->getPort());
     }
 
-    /** @return array<string, array{0: mixed}> */
+    /** @return non-empty-array<non-empty-string, array{mixed}> */
     public function invalidPorts(): array
     {
         return [
@@ -217,7 +220,7 @@ class UriTest extends TestCase
         $this->assertSame('https://user:pass@local.example.com:3001/foo?bar=baz#quz', (string) $new);
     }
 
-    /** @return array<string, array{0: mixed}> */
+    /** @return non-empty-array<non-empty-string, array{mixed}> */
     public function invalidPaths(): array
     {
         return [
@@ -255,7 +258,7 @@ class UriTest extends TestCase
         $this->assertSame('https://user:pass@local.example.com:3001/foo?baz=bat#quz', (string) $new);
     }
 
-    /** @return array<string, array{0: mixed}> */
+    /** @return non-empty-array<non-empty-string, array{mixed}> */
     public function invalidQueryStrings(): array
     {
         return [
@@ -301,7 +304,7 @@ class UriTest extends TestCase
         $this->assertSame('https://user:pass@local.example.com:3001/foo?bar=baz#quz', (string) $new);
     }
 
-    /** @return array<string, array{0: string, 1: string}> */
+    /** @return non-empty-array<non-empty-string, array{non-empty-string, non-empty-string}> */
     public function authorityInfo(): array
     {
         return [
@@ -314,6 +317,8 @@ class UriTest extends TestCase
 
     /**
      * @dataProvider authorityInfo
+     * @param non-empty-string $url
+     * @param non-empty-string $expected
      */
     public function testRetrievingAuthorityReturnsExpectedValues(string $url, string $expected): void
     {
@@ -374,7 +379,7 @@ class UriTest extends TestCase
         $this->assertSame('', $new->getScheme());
     }
 
-    /** @return array<string, array{0: string}> */
+    /** @return non-empty-array<non-empty-string, array{non-empty-string}> */
     public function invalidSchemes(): array
     {
         return [
@@ -388,6 +393,7 @@ class UriTest extends TestCase
 
     /**
      * @dataProvider invalidSchemes
+     * @param non-empty-string $scheme
      */
     public function testConstructWithUnsupportedSchemeRaisesAnException(string $scheme): void
     {
@@ -399,6 +405,7 @@ class UriTest extends TestCase
 
     /**
      * @dataProvider invalidSchemes
+     * @param non-empty-string $scheme
      */
     public function testMutatingWithUnsupportedSchemeRaisesAnException(string $scheme): void
     {
@@ -438,7 +445,7 @@ class UriTest extends TestCase
         $this->assertSame('%23/foo/bar', $new->getFragment());
     }
 
-    /** @return array<string, array{0: string, 1: int}> */
+    /** @return non-empty-array<non-empty-string, array{non-empty-string, positive-int}> */
     public function standardSchemePortCombinations(): array
     {
         return [
@@ -449,6 +456,8 @@ class UriTest extends TestCase
 
     /**
      * @dataProvider standardSchemePortCombinations
+     * @param non-empty-string $scheme
+     * @param positive-int $port
      */
     public function testAuthorityOmitsPortForStandardSchemePortCombinations(string $scheme, int $port): void
     {
@@ -459,7 +468,7 @@ class UriTest extends TestCase
         $this->assertSame('example.com', $uri->getAuthority());
     }
 
-    /** @return array<string, array{0: string, 1: string|int}> */
+    /** @return non-empty-array<string, array{'withScheme'|'withUserInfo'|'withHost'|'withPort'|'withPath'|'withQuery'|'withFragment', non-empty-string|positive-int}> */
     public function mutations(): array
     {
         return [
@@ -475,7 +484,8 @@ class UriTest extends TestCase
 
     /**
      * @dataProvider mutations
-     * @param string|int $value
+     * @param 'withScheme'|'withUserInfo'|'withHost'|'withPort'|'withPath'|'withQuery'|'withFragment' $method
+     * @param non-empty-string|positive-int $value
      */
     public function testMutationResetsUriStringPropertyInClone(string $method, $value): void
     {
@@ -496,6 +506,9 @@ class UriTest extends TestCase
         $this->assertSame($string, $p->getValue($uri));
     }
 
+    /**
+     * @group 40
+     */
     public function testPathIsProperlyEncoded(): void
     {
         $uri      = (new Uri())->withPath('/foo^bar');
@@ -510,7 +523,7 @@ class UriTest extends TestCase
         $this->assertSame($expected, $uri->getPath());
     }
 
-    /** @return array<string, array{0: string, 1: string}> */
+    /** @return non-empty-array<non-empty-string, array{non-empty-string, non-empty-string}> */
     public function queryStringsForEncoding(): array
     {
         return [
@@ -524,6 +537,8 @@ class UriTest extends TestCase
 
     /**
      * @dataProvider queryStringsForEncoding
+     * @param non-empty-string $query
+     * @param non-empty-string $expected
      */
     public function testQueryIsProperlyEncoded(string $query, string $expected): void
     {
@@ -533,6 +548,8 @@ class UriTest extends TestCase
 
     /**
      * @dataProvider queryStringsForEncoding
+     * @param non-empty-string $query
+     * @param non-empty-string $expected
      */
     public function testQueryIsNotDoubleEncoded(string $query, string $expected): void
     {
@@ -540,6 +557,9 @@ class UriTest extends TestCase
         $this->assertSame($expected, $uri->getQuery());
     }
 
+    /**
+     * @group 40
+     */
     public function testFragmentIsProperlyEncoded(): void
     {
         $uri      = (new Uri())->withFragment('/p^th?key^=`bar#b@z');
@@ -547,6 +567,9 @@ class UriTest extends TestCase
         $this->assertSame($expected, $uri->getFragment());
     }
 
+    /**
+     * @group 40
+     */
     public function testFragmentIsNotDoubleEncoded(): void
     {
         $expected = '/p%5Eth?key%5E=%60bar%23b@z';
@@ -561,7 +584,7 @@ class UriTest extends TestCase
         $this->assertSame('http://example.org/zend.com', (string) $uri);
     }
 
-    /** @return array<string, array{0: string, 1: mixed}> */
+    /** @return non-empty-array<string, array{'withScheme'|'withUserInfo'|'withHost'|'withPath'|'withQuery'|'withFragment', mixed}> */
     public function invalidStringComponentValues(): array
     {
         $methods = [
@@ -598,6 +621,7 @@ class UriTest extends TestCase
 
     /**
      * @dataProvider invalidStringComponentValues
+     * @param 'withScheme'|'withUserInfo'|'withHost'|'withPath'|'withQuery'|'withFragment' $method
      * @param mixed $value
      */
     public function testPassingInvalidValueToWithMethodRaisesException(string $method, $value): void
@@ -618,6 +642,8 @@ class UriTest extends TestCase
 
     /**
      * @dataProvider utf8PathsDataProvider
+     * @param non-empty-string $url
+     * @param non-empty-string $result
      */
     public function testUtf8Path(string $url, string $result): void
     {
@@ -626,7 +652,7 @@ class UriTest extends TestCase
         $this->assertSame($result, $uri->getPath());
     }
 
-    /** @return array<int, array{0: string, 1: string}> */
+    /** @return non-empty-list<array{non-empty-string, non-empty-string}> */
     public function utf8PathsDataProvider(): array
     {
         return [
@@ -639,6 +665,8 @@ class UriTest extends TestCase
 
     /**
      * @dataProvider utf8QueryStringsDataProvider
+     * @param non-empty-string $url
+     * @param non-empty-string $result
      */
     public function testUtf8Query(string $url, string $result): void
     {
@@ -647,7 +675,7 @@ class UriTest extends TestCase
         $this->assertSame($result, $uri->getQuery());
     }
 
-    /** @return array<int, array{0: string, 1: string}> */
+    /** @return non-empty-list<array{non-empty-string, non-empty-string}> */
     public function utf8QueryStringsDataProvider(): array
     {
         return [

--- a/test/functions/MarshalUriFromSapiTest.php
+++ b/test/functions/MarshalUriFromSapiTest.php
@@ -56,7 +56,7 @@ class MarshalUriFromSapiTest extends TestCase
         self::assertSame($expectedScheme, $url->getScheme());
     }
 
-    /** @return array<string, array{0:string, 1: string}> */
+    /** @return array<non-empty-string, array{string, non-empty-string}> */
     public function returnsUrlWithCorrectHttpSchemeFromArraysProvider(): array
     {
         return [
@@ -83,7 +83,7 @@ class MarshalUriFromSapiTest extends TestCase
         self::assertSame($expectedHost, $uri->getHost());
     }
 
-    /** @return array<string, array{0:string, 1: string, 2: array, 3: array}> */
+    /** @return array<string, array{non-empty-string, non-empty-string, array<non-empty-string, non-empty-string>, array<non-empty-string, non-empty-string>}> */
     public function returnsUrlWithCorrectSchemeAndHostFromArrays(): array
     {
         return [


### PR DESCRIPTION
In https://github.com/laminas/laminas-diactoros/pull/104 (duplicate), we improved the types of internal and
public API. These were mixed with coding style improvements.

The coding style improvements have been merged separately via https://github.com/laminas/laminas-diactoros/pull/103,
so this patch only includes the type/docblock improvements, which should ease the potential evolution of the
API of this package.

|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes
