### PR TITLE
Remove duplicate `config.allow-plugins` key in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,6 @@
         "sort-packages": true,
         "platform": {
             "php": "7.3.99"
-        },
-        "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true
         }
     },
     "extra": {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

The duplicate was added in 2539f322722a5d35c13479575889aba9d92cace4.