### PR TITLE
Add test to detect regression described in #111

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,4 +7,5 @@
 /mkdocs.yml export-ignore
 /phpcs.xml export-ignore
 /phpunit.xml.dist export-ignore
+/renovate.json export-ignore
 /test/ export-ignore

--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,6 @@
         "sort-packages": true,
         "platform": {
             "php": "7.3.99"
-        },
-        "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true
         }
     },
     "extra": {

--- a/test/ServerRequestFilter/FilterUsingXForwardedHeadersTest.php
+++ b/test/ServerRequestFilter/FilterUsingXForwardedHeadersTest.php
@@ -380,7 +380,7 @@ class FilterUsingXForwardedHeadersTest extends TestCase
             [
                 'Host'              => 'localhost',
                 'X-Forwarded-Host'  => 'example.com:4433',
-                'X-Forwarded-Port'  => '4433',
+                'X-Forwarded-Port'  => '8433',
                 'X-Forwarded-Proto' => 'https',
             ]
         );

--- a/test/ServerRequestFilter/FilterUsingXForwardedHeadersTest.php
+++ b/test/ServerRequestFilter/FilterUsingXForwardedHeadersTest.php
@@ -368,4 +368,30 @@ class FilterUsingXForwardedHeadersTest extends TestCase
         $uri             = $filteredRequest->getUri();
         $this->assertSame($expectedScheme, $uri->getScheme());
     }
+
+    public function testPortExtractedFromXForwardedHostHeader(): void
+    {
+        $request = new ServerRequest(
+            ['REMOTE_ADDR' => '192.168.1.1'],
+            [],
+            'http://localhost:80/foo/bar',
+            'GET',
+            'php://temp',
+            [
+                'Host'              => 'localhost',
+                'X-Forwarded-Host'  => 'example.com:4433',
+                'X-Forwarded-Port'  => '4433',
+                'X-Forwarded-Proto' => 'https',
+            ]
+        );
+
+        $filter = FilterUsingXForwardedHeaders::trustAny();
+
+        $filteredRequest = $filter($request);
+        $filteredUri     = $filteredRequest->getUri();
+        $this->assertNotSame($request->getUri(), $filteredUri);
+        $this->assertSame('example.com', $filteredUri->getHost());
+        $this->assertSame(4433, $filteredUri->getPort());
+        $this->assertSame('https', $filteredUri->getScheme());
+    }
 }


### PR DESCRIPTION
Signed-off-by: Denis Ponomarev <ponomarev@gmail.com>

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   |no
| RFC           | no
| QA            | yes

### Description

`FilterUsingXForwardedHeaders` should accept `host:port` pair in `X-FORWARDED-HOST` header. 

Test added to detect it parsed incorrectly.

