### PR TITLE
Fix static return type in RequestTrait

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -69,7 +69,6 @@
     </PossiblyNullOperand>
   </file>
   <file src="src/Request/ArraySerializer.php">
-    <LessSpecificReturnStatement occurrences="1"/>
     <MixedArgument occurrences="6">
       <code>$headers</code>
       <code>$method</code>
@@ -85,12 +84,8 @@
       <code>$requestTarget</code>
       <code>$uri</code>
     </MixedAssignment>
-    <MoreSpecificReturnType occurrences="1">
-      <code>Request</code>
-    </MoreSpecificReturnType>
   </file>
   <file src="src/Request/Serializer.php">
-    <LessSpecificReturnStatement occurrences="1"/>
     <MixedArgument occurrences="5">
       <code>$body</code>
       <code>$headers</code>
@@ -101,19 +96,11 @@
     <MixedArgumentTypeCoercion occurrences="1">
       <code>$request-&gt;getHeaders()</code>
     </MixedArgumentTypeCoercion>
-    <MoreSpecificReturnType occurrences="1">
-      <code>Request</code>
-    </MoreSpecificReturnType>
   </file>
   <file src="src/RequestTrait.php">
     <DocblockTypeContradiction occurrences="1">
       <code>is_string($method)</code>
     </DocblockTypeContradiction>
-    <LessSpecificImplementedReturnType occurrences="3">
-      <code>RequestInterface</code>
-      <code>RequestInterface</code>
-      <code>RequestInterface</code>
-    </LessSpecificImplementedReturnType>
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$requestTarget</code>
     </MoreSpecificImplementedParamType>

--- a/src/RequestTrait.php
+++ b/src/RequestTrait.php
@@ -158,6 +158,7 @@ trait RequestTrait
      *
      * @param string $requestTarget
      * @throws Exception\InvalidArgumentException If the request target is invalid.
+     * @return static
      */
     public function withRequestTarget($requestTarget): RequestInterface
     {
@@ -195,6 +196,7 @@ trait RequestTrait
      *
      * @param string $method Case-insensitive method.
      * @throws Exception\InvalidArgumentException For invalid HTTP methods.
+     * @return static
      */
     public function withMethod($method): RequestInterface
     {
@@ -242,6 +244,7 @@ trait RequestTrait
      *
      * @param UriInterface $uri New request URI to use.
      * @param bool $preserveHost Preserve the original state of the Host header.
+     * @return static
      */
     public function withUri(UriInterface $uri, $preserveHost = false): RequestInterface
     {

--- a/test/StaticAnalysis/RequestInterfaceStaticReturnTypes.php
+++ b/test/StaticAnalysis/RequestInterfaceStaticReturnTypes.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Diactoros\StaticAnalysis;
+
+use Laminas\Diactoros\Request;
+use Laminas\Diactoros\ServerRequest;
+use Laminas\Diactoros\Uri;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class RequestInterfaceStaticReturnTypes
+{
+    public function changeMethodOfServerRequest(ServerRequest $request): ServerRequestInterface
+    {
+        return $request->withMethod('GET');
+    }
+
+    public function changeRequestTargetOfServerRequest(ServerRequest $request): ServerRequestInterface
+    {
+        return $request->withRequestTarget('foo');
+    }
+
+    public function changeUriOfServerRequest(ServerRequest $request): ServerRequestInterface
+    {
+        return $request->withUri(new Uri('/there'));
+    }
+
+    public function changeMethodOfRequest(Request $request): RequestInterface
+    {
+        return $request->withMethod('GET');
+    }
+
+    public function changeRequestTargetOfRequest(Request $request): RequestInterface
+    {
+        return $request->withRequestTarget('foo');
+    }
+
+    public function changeUriOfRequest(Request $request): RequestInterface
+    {
+        return $request->withUri(new Uri('/there'));
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| QA            | yes

### Description

Solves psalm issues here and for consumers where a call to `ServerRequest::withWhatever()` would be inferred as `RequestInterface` rather than `ServerRequestInterface`