### PR TITLE
Apply PHP 8.2's `SensitiveParameter` attribute to `Uri::withUserInfo()`

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -314,6 +314,9 @@
     <RedundantConditionGivenDocblockType occurrences="1">
       <code>gettype($port)</code>
     </RedundantConditionGivenDocblockType>
+    <UndefinedAttributeClass occurrences="1">
+      <code>SensitiveParameter</code>
+    </UndefinedAttributeClass>
   </file>
   <file src="src/functions/create_uploaded_file.legacy.php">
     <MixedArgument occurrences="1">
@@ -467,9 +470,6 @@
     </MoreSpecificReturnType>
   </file>
   <file src="test/CallbackStreamTest.php">
-    <MissingClosureReturnType occurrences="1">
-      <code>function () {</code>
-    </MissingClosureReturnType>
     <MixedAssignment occurrences="2">
       <code>$ret</code>
       <code>$ret</code>

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laminas\Diactoros;
 
 use Psr\Http\Message\UriInterface;
+use SensitiveParameter;
 
 use function array_keys;
 use function explode;
@@ -228,6 +229,9 @@ class Uri implements UriInterface
         return $new;
     }
 
+    // The following rule is buggy for parameters attributes
+    // phpcs:disable SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing.NoSpaceBetweenTypeHintAndParameter
+
     /**
      * Create and return a new instance containing the provided user credentials.
      *
@@ -236,8 +240,11 @@ class Uri implements UriInterface
      *
      * {@inheritdoc}
      */
-    public function withUserInfo($user, $password = null): UriInterface
-    {
+    public function withUserInfo(
+        $user,
+        #[SensitiveParameter]
+        $password = null
+    ): UriInterface {
         if (! is_string($user)) {
             throw new Exception\InvalidArgumentException(sprintf(
                 '%s expects a string user argument; received %s',
@@ -268,6 +275,8 @@ class Uri implements UriInterface
 
         return $new;
     }
+
+    // phpcs:enable SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing.NoSpaceBetweenTypeHintAndParameter
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | maybe

### Description

Technically the `$password` will end up in the URI anyway when stringifying it.

Adding the Attribute is simple though and absolves the reader from needing to
consider whether not having the attribute in this specific instance is safe or
not.

-------------------

I've searched the codebase for “password“, “auth” and “secret” and this is the only place where the attribute makes sense.