### PR TITLE
Remove obsolete check for PHP_VERSION_ID in Stream

### DIFF
--- a/src/Stream.php
+++ b/src/Stream.php
@@ -29,7 +29,6 @@ use function stream_get_contents;
 use function stream_get_meta_data;
 use function strstr;
 
-use const PHP_VERSION_ID;
 use const SEEK_SET;
 
 /**
@@ -359,7 +358,7 @@ class Stream implements StreamInterface, Stringable
             return in_array(get_resource_type($resource), self::ALLOWED_STREAM_RESOURCE_TYPES, true);
         }
 
-        if (PHP_VERSION_ID >= 80000 && $resource instanceof GdImage) {
+        if ($resource instanceof GdImage) {
             return true;
         }
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | maybe

### Description

PHP 8.0 is the minimum version supported since 3abe659c6300fde8e71ae0c644b8a4, thus making this check always true.