### PR TITLE
Allow usage with PSR-7 v1.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "require": {
         "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
         "psr/http-factory": "^1.0",
-        "psr/http-message": "^1.0"
+        "psr/http-message": "^1.1"
     },
     "require-dev": {
         "ext-curl": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c25e73f49b971e1a04c8a20ddf532540",
+    "content-hash": "ac4ba7c36a4a5e1cecb140dd5544d8ba",
     "packages": [
         {
             "name": "psr/http-factory",
@@ -63,25 +63,25 @@
         },
         {
             "name": "psr/http-message",
-            "version": "1.0.1",
+            "version": "1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-message.git",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
+                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
@@ -110,9 +110,9 @@
                 "response"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-message/tree/master"
+                "source": "https://github.com/php-fig/http-message/tree/1.1"
             },
-            "time": "2016-08-06T14:39:51+00:00"
+            "time": "2023-04-04T09:50:52+00:00"
         }
     ],
     "packages-dev": [
@@ -858,16 +858,16 @@
         },
         {
             "name": "fidry/cpu-core-counter",
-            "version": "0.4.1",
+            "version": "0.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theofidry/cpu-core-counter.git",
-                "reference": "79261cc280aded96d098e1b0e0ba0c4881b432c2"
+                "reference": "b58e5a3933e541dc286cc91fc4f3898bbc6f1623"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/79261cc280aded96d098e1b0e0ba0c4881b432c2",
-                "reference": "79261cc280aded96d098e1b0e0ba0c4881b432c2",
+                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/b58e5a3933e541dc286cc91fc4f3898bbc6f1623",
+                "reference": "b58e5a3933e541dc286cc91fc4f3898bbc6f1623",
                 "shasum": ""
             },
             "require": {
@@ -907,7 +907,7 @@
             ],
             "support": {
                 "issues": "https://github.com/theofidry/cpu-core-counter/issues",
-                "source": "https://github.com/theofidry/cpu-core-counter/tree/0.4.1"
+                "source": "https://github.com/theofidry/cpu-core-counter/tree/0.5.1"
             },
             "funding": [
                 {
@@ -915,7 +915,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-12-16T22:01:02+00:00"
+            "time": "2022-12-24T12:35:10+00:00"
         },
         {
             "name": "http-interop/http-factory-tests",
@@ -1024,16 +1024,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.11.0",
+            "version": "1.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614"
+                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/14daed4296fae74d9e3201d2c4925d1acb7aa614",
-                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
+                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
                 "shasum": ""
             },
             "require": {
@@ -1071,7 +1071,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.0"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.1"
             },
             "funding": [
                 {
@@ -1079,7 +1079,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-03T13:19:32+00:00"
+            "time": "2023-03-08T13:26:56+00:00"
         },
         {
             "name": "netresearch/jsonmapper",
@@ -1134,16 +1134,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.15.3",
+            "version": "v4.15.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "570e980a201d8ed0236b0a62ddf2c9cbb2034039"
+                "reference": "6bb5176bc4af8bcb7d926f88718db9b96a2d4290"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/570e980a201d8ed0236b0a62ddf2c9cbb2034039",
-                "reference": "570e980a201d8ed0236b0a62ddf2c9cbb2034039",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/6bb5176bc4af8bcb7d926f88718db9b96a2d4290",
+                "reference": "6bb5176bc4af8bcb7d926f88718db9b96a2d4290",
                 "shasum": ""
             },
             "require": {
@@ -1184,9 +1184,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.3"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.4"
             },
-            "time": "2023-01-16T22:05:37+00:00"
+            "time": "2023-03-05T19:49:14+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -1569,23 +1569,23 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.24",
+            "version": "9.2.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "2cf940ebc6355a9d430462811b5aaa308b174bed"
+                "reference": "443bc6912c9bd5b409254a40f4b0f4ced7c80ea1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2cf940ebc6355a9d430462811b5aaa308b174bed",
-                "reference": "2cf940ebc6355a9d430462811b5aaa308b174bed",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/443bc6912c9bd5b409254a40f4b0f4ced7c80ea1",
+                "reference": "443bc6912c9bd5b409254a40f4b0f4ced7c80ea1",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.14",
+                "nikic/php-parser": "^4.15",
                 "php": ">=7.3",
                 "phpunit/php-file-iterator": "^3.0.3",
                 "phpunit/php-text-template": "^2.0.2",
@@ -1600,8 +1600,8 @@
                 "phpunit/phpunit": "^9.3"
             },
             "suggest": {
-                "ext-pcov": "*",
-                "ext-xdebug": "*"
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
             "type": "library",
             "extra": {
@@ -1634,7 +1634,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.24"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.26"
             },
             "funding": [
                 {
@@ -1642,7 +1642,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-26T08:26:55+00:00"
+            "time": "2023-03-06T12:58:08+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1887,16 +1887,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.28",
+            "version": "9.6.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "954ca3113a03bf780d22f07bf055d883ee04b65e"
+                "reference": "b65d59a059d3004a040c16a82e07bbdf6cfdd115"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/954ca3113a03bf780d22f07bf055d883ee04b65e",
-                "reference": "954ca3113a03bf780d22f07bf055d883ee04b65e",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b65d59a059d3004a040c16a82e07bbdf6cfdd115",
+                "reference": "b65d59a059d3004a040c16a82e07bbdf6cfdd115",
                 "shasum": ""
             },
             "require": {
@@ -1929,8 +1929,8 @@
                 "sebastian/version": "^3.0.2"
             },
             "suggest": {
-                "ext-soap": "*",
-                "ext-xdebug": "*"
+                "ext-soap": "To be able to generate mocks based on WSDL files",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
             "bin": [
                 "phpunit"
@@ -1938,7 +1938,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.5-dev"
+                    "dev-master": "9.6-dev"
                 }
             },
             "autoload": {
@@ -1969,7 +1969,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.28"
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.6"
             },
             "funding": [
                 {
@@ -1985,7 +1986,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-14T12:32:24+00:00"
+            "time": "2023-03-27T11:43:46+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -2516,16 +2517,16 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "5.1.4",
+            "version": "5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7"
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/1b5dff7bb151a4db11d49d90e5408e4e938270f7",
-                "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
                 "shasum": ""
             },
             "require": {
@@ -2567,7 +2568,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.4"
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
             },
             "funding": [
                 {
@@ -2575,7 +2576,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-04-03T09:37:03+00:00"
+            "time": "2023-02-03T06:03:51+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -2889,16 +2890,16 @@
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.4",
+            "version": "4.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172"
+                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/cd9d8cf3c5804de4341c283ed787f099f5506172",
-                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
+                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
                 "shasum": ""
             },
             "require": {
@@ -2937,10 +2938,10 @@
                 }
             ],
             "description": "Provides functionality to recursively process PHP variables",
-            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.5"
             },
             "funding": [
                 {
@@ -2948,7 +2949,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:17:30+00:00"
+            "time": "2023-02-03T06:07:39+00:00"
         },
         {
             "name": "sebastian/resource-operations",
@@ -3007,16 +3008,16 @@
         },
         {
             "name": "sebastian/type",
-            "version": "3.2.0",
+            "version": "3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e"
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e",
-                "reference": "fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
                 "shasum": ""
             },
             "require": {
@@ -3051,7 +3052,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/3.2.0"
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
             },
             "funding": [
                 {
@@ -3059,7 +3060,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-12T14:47:03+00:00"
+            "time": "2023-02-03T06:13:03+00:00"
         },
         {
             "name": "sebastian/version",
@@ -3177,26 +3178,25 @@
         },
         {
             "name": "spatie/array-to-xml",
-            "version": "2.17.1",
+            "version": "3.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/array-to-xml.git",
-                "reference": "5cbec9c6ab17e320c58a259f0cebe88bde4a7c46"
+                "reference": "13f76acef5362d15c71ae1ac6350cc3df5e25e43"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/5cbec9c6ab17e320c58a259f0cebe88bde4a7c46",
-                "reference": "5cbec9c6ab17e320c58a259f0cebe88bde4a7c46",
+                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/13f76acef5362d15c71ae1ac6350cc3df5e25e43",
+                "reference": "13f76acef5362d15c71ae1ac6350cc3df5e25e43",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
-                "php": "^7.4|^8.0"
+                "php": "^8.0"
             },
             "require-dev": {
                 "mockery/mockery": "^1.2",
                 "pestphp/pest": "^1.21",
-                "phpunit/phpunit": "^9.0",
                 "spatie/pest-plugin-snapshots": "^1.1"
             },
             "type": "library",
@@ -3225,7 +3225,7 @@
                 "xml"
             ],
             "support": {
-                "source": "https://github.com/spatie/array-to-xml/tree/2.17.1"
+                "source": "https://github.com/spatie/array-to-xml/tree/3.1.5"
             },
             "funding": [
                 {
@@ -3237,20 +3237,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-12-26T08:22:07+00:00"
+            "time": "2022-12-24T13:43:51+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.7.1",
+            "version": "3.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619"
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
-                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
                 "shasum": ""
             },
             "require": {
@@ -3286,14 +3286,15 @@
             "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
-                "standards"
+                "standards",
+                "static analysis"
             ],
             "support": {
                 "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2022-06-18T07:21:10+00:00"
+            "time": "2023-02-22T23:07:41+00:00"
         },
         {
             "name": "symfony/console",
@@ -4002,22 +4003,22 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "5.6.0",
+            "version": "5.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "e784128902dfe01d489c4123d69918a9f3c1eac5"
+                "reference": "8b9ad1eb9e8b7d3101f949291da2b9f7767cd163"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/e784128902dfe01d489c4123d69918a9f3c1eac5",
-                "reference": "e784128902dfe01d489c4123d69918a9f3c1eac5",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/8b9ad1eb9e8b7d3101f949291da2b9f7767cd163",
+                "reference": "8b9ad1eb9e8b7d3101f949291da2b9f7767cd163",
                 "shasum": ""
             },
             "require": {
                 "amphp/amp": "^2.4.2",
                 "amphp/byte-stream": "^1.5",
-                "composer/package-versions-deprecated": "^1.10.0",
+                "composer-runtime-api": "^2",
                 "composer/semver": "^1.4 || ^2.0 || ^3.0",
                 "composer/xdebug-handler": "^2.0 || ^3.0",
                 "dnoegel/php-xdg-base-dir": "^0.1.1",
@@ -4030,12 +4031,12 @@
                 "ext-tokenizer": "*",
                 "felixfbecker/advanced-json-rpc": "^3.1",
                 "felixfbecker/language-server-protocol": "^1.5.2",
-                "fidry/cpu-core-counter": "^0.4.0",
+                "fidry/cpu-core-counter": "^0.4.1 || ^0.5.1",
                 "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
-                "nikic/php-parser": "^4.13",
+                "nikic/php-parser": "^4.14",
                 "php": "^7.4 || ~8.0.0 || ~8.1.0 || ~8.2.0",
                 "sebastian/diff": "^4.0 || ^5.0",
-                "spatie/array-to-xml": "^2.17.0",
+                "spatie/array-to-xml": "^2.17.0 || ^3.0",
                 "symfony/console": "^4.1.6 || ^5.0 || ^6.0",
                 "symfony/filesystem": "^5.4 || ^6.0"
             },
@@ -4043,14 +4044,15 @@
                 "psalm/psalm": "self.version"
             },
             "require-dev": {
+                "amphp/phpunit-util": "^2.0",
                 "bamarni/composer-bin-plugin": "^1.4",
-                "brianium/paratest": "^6.0",
+                "brianium/paratest": "^6.9",
                 "ext-curl": "*",
                 "mockery/mockery": "^1.5",
                 "nunomaduro/mock-final-classes": "^1.1",
                 "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpstan/phpdoc-parser": "^1.6",
-                "phpunit/phpunit": "^9.5",
+                "phpunit/phpunit": "^9.6",
                 "psalm/plugin-mockery": "^1.1",
                 "psalm/plugin-phpunit": "^0.18",
                 "slevomat/coding-standard": "^8.4",
@@ -4096,34 +4098,35 @@
             "keywords": [
                 "code",
                 "inspection",
-                "php"
+                "php",
+                "static analysis"
             ],
             "support": {
                 "issues": "https://github.com/vimeo/psalm/issues",
-                "source": "https://github.com/vimeo/psalm/tree/5.6.0"
+                "source": "https://github.com/vimeo/psalm/tree/5.9.0"
             },
-            "time": "2023-01-23T20:32:47+00:00"
+            "time": "2023-03-29T21:38:21+00:00"
         },
         {
             "name": "webimpress/coding-standard",
-            "version": "1.2.4",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webimpress/coding-standard.git",
-                "reference": "cd0c4b0b97440c337c1f7da17b524674ca2f9ca9"
+                "reference": "b26557e2386711ecb74f22718f4b4bde5ddbc899"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webimpress/coding-standard/zipball/cd0c4b0b97440c337c1f7da17b524674ca2f9ca9",
-                "reference": "cd0c4b0b97440c337c1f7da17b524674ca2f9ca9",
+                "url": "https://api.github.com/repos/webimpress/coding-standard/zipball/b26557e2386711ecb74f22718f4b4bde5ddbc899",
+                "reference": "b26557e2386711ecb74f22718f4b4bde5ddbc899",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.3 || ^8.0",
-                "squizlabs/php_codesniffer": "^3.6.2"
+                "squizlabs/php_codesniffer": "^3.7.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5.13"
+                "phpunit/phpunit": "^9.6.4"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -4149,7 +4152,7 @@
             ],
             "support": {
                 "issues": "https://github.com/webimpress/coding-standard/issues",
-                "source": "https://github.com/webimpress/coding-standard/tree/1.2.4"
+                "source": "https://github.com/webimpress/coding-standard/tree/1.3.1"
             },
             "funding": [
                 {
@@ -4157,7 +4160,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-02-15T19:52:12+00:00"
+            "time": "2023-03-09T15:05:18+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.6.0@e784128902dfe01d489c4123d69918a9f3c1eac5">
+<files psalm-version="5.9.0@8b9ad1eb9e8b7d3101f949291da2b9f7767cd163">
   <file src="src/CallbackStream.php">
     <ImplementedReturnTypeMismatch>
       <code>null|callable</code>
@@ -10,20 +10,20 @@
   </file>
   <file src="src/Exception/DeserializationException.php">
     <PossiblyInvalidArgument>
-      <code>$previous-&gt;getCode()</code>
-      <code>$previous-&gt;getCode()</code>
+      <code><![CDATA[$previous->getCode()]]></code>
+      <code><![CDATA[$previous->getCode()]]></code>
     </PossiblyInvalidArgument>
   </file>
   <file src="src/MessageTrait.php">
     <DocblockTypeContradiction>
       <code>! is_string($name)</code>
-      <code>! is_string($stream) &amp;&amp; ! is_resource($stream)</code>
+      <code><![CDATA[! is_string($stream) && ! is_resource($stream)]]></code>
     </DocblockTypeContradiction>
     <InvalidArrayOffset>
-      <code>$new-&gt;headerNames[$normalized]</code>
-      <code>$this-&gt;headerNames[strtolower($header)]</code>
-      <code>$this-&gt;headerNames[strtolower($header)]</code>
-      <code>$this-&gt;headerNames[strtolower($name)]</code>
+      <code><![CDATA[$new->headerNames[$normalized]]]></code>
+      <code><![CDATA[$this->headerNames[strtolower($header)]]]></code>
+      <code><![CDATA[$this->headerNames[strtolower($header)]]]></code>
+      <code><![CDATA[$this->headerNames[strtolower($name)]]]></code>
     </InvalidArrayOffset>
     <InvalidPropertyAssignmentValue>
       <code>$headerNames</code>
@@ -48,8 +48,8 @@
       <code>$header</code>
     </ParamNameMismatch>
     <PropertyTypeCoercion>
-      <code>$new-&gt;headerNames</code>
-      <code>$new-&gt;headers</code>
+      <code><![CDATA[$new->headerNames]]></code>
+      <code><![CDATA[$new->headers]]></code>
     </PropertyTypeCoercion>
     <RedundantCondition>
       <code>gettype($version)</code>
@@ -67,12 +67,12 @@
       <code>$maxLength</code>
     </MixedArgument>
     <PossiblyNullArgument>
-      <code>$this-&gt;resource</code>
+      <code><![CDATA[$this->resource]]></code>
     </PossiblyNullArgument>
   </file>
   <file src="src/RelativeStream.php">
     <PossiblyNullOperand>
-      <code>$this-&gt;decoratedStream-&gt;getSize()</code>
+      <code><![CDATA[$this->decoratedStream->getSize()]]></code>
     </PossiblyNullOperand>
   </file>
   <file src="src/Request/ArraySerializer.php">
@@ -82,7 +82,7 @@
       <code>$protocolVersion</code>
       <code>$requestTarget</code>
       <code>$uri</code>
-      <code>self::getValueFromKey($serializedRequest, 'body')</code>
+      <code><![CDATA[self::getValueFromKey($serializedRequest, 'body')]]></code>
     </MixedArgument>
     <MixedAssignment>
       <code>$headers</code>
@@ -101,19 +101,16 @@
       <code>$version</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion>
-      <code>$request-&gt;getHeaders()</code>
+      <code><![CDATA[$request->getHeaders()]]></code>
     </MixedArgumentTypeCoercion>
   </file>
   <file src="src/RequestTrait.php">
     <DocblockTypeContradiction>
       <code>is_string($method)</code>
     </DocblockTypeContradiction>
-    <MoreSpecificImplementedParamType>
-      <code>$requestTarget</code>
-    </MoreSpecificImplementedParamType>
     <PossiblyNullOperand>
-      <code>$this-&gt;uri-&gt;getPort()</code>
-      <code>$uri-&gt;getPort()</code>
+      <code><![CDATA[$this->uri->getPort()]]></code>
+      <code><![CDATA[$uri->getPort()]]></code>
     </PossiblyNullOperand>
   </file>
   <file src="src/Response.php">
@@ -142,7 +139,7 @@
       <code>$protocolVersion</code>
       <code>$reasonPhrase</code>
       <code>$statusCode</code>
-      <code>self::getValueFromKey($serializedResponse, 'body')</code>
+      <code><![CDATA[self::getValueFromKey($serializedResponse, 'body')]]></code>
     </MixedArgument>
     <MixedAssignment>
       <code>$headers</code>
@@ -191,7 +188,7 @@
       <code>$version</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion>
-      <code>$response-&gt;getHeaders()</code>
+      <code><![CDATA[$response->getHeaders()]]></code>
     </MixedArgumentTypeCoercion>
     <RedundantCast>
       <code>(int) $status</code>
@@ -209,7 +206,7 @@
   </file>
   <file src="src/ServerRequest.php">
     <DocblockTypeContradiction>
-      <code>! is_array($data) &amp;&amp; ! is_object($data) &amp;&amp; null !== $data</code>
+      <code><![CDATA[! is_array($data) && ! is_object($data) && null !== $data]]></code>
     </DocblockTypeContradiction>
     <ParamNameMismatch>
       <code>$attribute</code>
@@ -218,7 +215,7 @@
   </file>
   <file src="src/ServerRequestFactory.php">
     <LessSpecificReturnStatement>
-      <code>$requestFilter(new ServerRequest(
+      <code><![CDATA[$requestFilter(new ServerRequest(
             $server,
             $files,
             UriFactory::createFromSapi($server, $headers),
@@ -229,10 +226,10 @@
             $query ?: $_GET,
             $body ?: $_POST,
             marshalProtocolVersionFromSapi($server)
-        ))</code>
+        ))]]></code>
     </LessSpecificReturnStatement>
     <MixedArgument>
-      <code>$headers['cookie']</code>
+      <code><![CDATA[$headers['cookie']]]></code>
     </MixedArgument>
     <MixedArgumentTypeCoercion>
       <code>$headers</code>
@@ -259,15 +256,15 @@
       <code>$proxyCIDRList</code>
     </LessSpecificReturnStatement>
     <MoreSpecificReturnType>
-      <code>list&lt;non-empty-string&gt;</code>
+      <code><![CDATA[list<non-empty-string>]]></code>
     </MoreSpecificReturnType>
   </file>
   <file src="src/Stream.php">
     <PossiblyNullArgument>
       <code>$resource</code>
-      <code>$this-&gt;resource</code>
-      <code>$this-&gt;resource</code>
-      <code>$this-&gt;resource</code>
+      <code><![CDATA[$this->resource]]></code>
+      <code><![CDATA[$this->resource]]></code>
+      <code><![CDATA[$this->resource]]></code>
     </PossiblyNullArgument>
   </file>
   <file src="src/StreamFactory.php">
@@ -280,7 +277,7 @@
       <code>! is_string($targetPath)</code>
     </DocblockTypeContradiction>
     <PossiblyNullArgument>
-      <code>$this-&gt;file</code>
+      <code><![CDATA[$this->file]]></code>
     </PossiblyNullArgument>
   </file>
   <file src="src/UploadedFileFactory.php">
@@ -289,33 +286,54 @@
     </PossiblyNullArgument>
   </file>
   <file src="src/Uri.php">
-    <DocblockTypeContradiction>
+    <MixedArgument>
+      <code>$key</code>
+      <code>$key</code>
+      <code>$matches[0]</code>
+      <code>$value</code>
+      <code>is_object($fragment) ? $fragment::class : gettype($fragment)</code>
+      <code>is_object($host) ? $host::class : gettype($host)</code>
+      <code>is_object($password) ? $password::class : gettype($password)</code>
+      <code>is_object($port) ? $port::class : gettype($port)</code>
+      <code>is_object($scheme) ? $scheme::class : gettype($scheme)</code>
+      <code>is_object($user) ? $user::class : gettype($user)</code>
+    </MixedArgument>
+    <PossiblyNullOperand>
+      <code><![CDATA[$this->port]]></code>
+    </PossiblyNullOperand>
+    <RedundantCast>
+      <code>(int) $port</code>
+    </RedundantCast>
+    <RedundantCondition>
+      <code>gettype($fragment)</code>
+      <code>gettype($host)</code>
+      <code>gettype($password)</code>
+      <code>gettype($port)</code>
+      <code>gettype($scheme)</code>
+      <code>gettype($user)</code>
+    </RedundantCondition>
+    <TypeDoesNotContainType>
       <code>! is_numeric($port)</code>
+      <code>! is_numeric($port) || is_float($port)</code>
+      <code>! is_numeric($port) || is_float($port)</code>
       <code>is_float($port)</code>
+      <code>is_object($fragment)</code>
+      <code>is_object($host)</code>
+      <code>is_object($password)</code>
       <code>is_object($port)</code>
+      <code>is_object($scheme)</code>
+      <code>is_object($user)</code>
       <code>is_string($fragment)</code>
       <code>is_string($host)</code>
       <code>is_string($path)</code>
       <code>is_string($query)</code>
       <code>is_string($scheme)</code>
       <code>is_string($user)</code>
-      <code>null !== $password &amp;&amp; ! is_string($password)</code>
-    </DocblockTypeContradiction>
-    <MixedArgument>
-      <code>$key</code>
-      <code>$key</code>
-      <code>$matches[0]</code>
-      <code>$value</code>
-    </MixedArgument>
-    <PossiblyNullOperand>
-      <code>$this-&gt;port</code>
-    </PossiblyNullOperand>
-    <RedundantCastGivenDocblockType>
-      <code>(int) $port</code>
-    </RedundantCastGivenDocblockType>
-    <RedundantConditionGivenDocblockType>
-      <code>gettype($port)</code>
-    </RedundantConditionGivenDocblockType>
+      <code><![CDATA[null !== $password && ! is_string($password)]]></code>
+    </TypeDoesNotContainType>
+    <UndefinedAttributeClass>
+      <code>SensitiveParameter</code>
+    </UndefinedAttributeClass>
   </file>
   <file src="src/functions/create_uploaded_file.legacy.php">
     <MixedArgument>
@@ -324,10 +342,10 @@
   </file>
   <file src="src/functions/create_uploaded_file.php">
     <MixedArgument>
-      <code>$spec['error']</code>
-      <code>$spec['name'] ?? null</code>
-      <code>$spec['tmp_name']</code>
-      <code>$spec['type'] ?? null</code>
+      <code><![CDATA[$spec['error']]]></code>
+      <code><![CDATA[$spec['name'] ?? null]]></code>
+      <code><![CDATA[$spec['tmp_name']]]></code>
+      <code><![CDATA[$spec['type'] ?? null]]></code>
     </MixedArgument>
   </file>
   <file src="src/functions/marshal_headers_from_sapi.legacy.php">
@@ -352,8 +370,8 @@
       <code>string</code>
     </MixedInferredReturnType>
     <MixedReturnStatement>
-      <code>$server['REQUEST_METHOD'] ?? 'GET'</code>
-      <code>$server['REQUEST_METHOD'] ?? 'GET'</code>
+      <code><![CDATA[$server['REQUEST_METHOD'] ?? 'GET']]></code>
+      <code><![CDATA[$server['REQUEST_METHOD'] ?? 'GET']]></code>
     </MixedReturnStatement>
   </file>
   <file src="src/functions/marshal_protocol_version_from_sapi.legacy.php">
@@ -363,7 +381,7 @@
   </file>
   <file src="src/functions/marshal_protocol_version_from_sapi.php">
     <MixedArgument>
-      <code>$server['SERVER_PROTOCOL']</code>
+      <code><![CDATA[$server['SERVER_PROTOCOL']]]></code>
     </MixedArgument>
   </file>
   <file src="src/functions/marshal_uri_from_sapi.legacy.php">
@@ -383,14 +401,14 @@
       <code>static function (string $name, array $headers, $default = null) {</code>
     </MissingClosureReturnType>
     <MixedArgument>
-      <code>$getHeaderFromArray('x-forwarded-proto', $headers, '')</code>
+      <code><![CDATA[$getHeaderFromArray('x-forwarded-proto', $headers, '')]]></code>
       <code>$host</code>
       <code>$host</code>
       <code>$host</code>
       <code>$host</code>
       <code>$port</code>
       <code>$requestUri</code>
-      <code>$server['QUERY_STRING']</code>
+      <code><![CDATA[$server['QUERY_STRING']]]></code>
     </MixedArgument>
     <MixedArgumentTypeCoercion>
       <code>$headers[$header]</code>
@@ -407,7 +425,7 @@
       <code>string</code>
     </MixedInferredReturnType>
     <MixedOperand>
-      <code>$server['SERVER_ADDR']</code>
+      <code><![CDATA[$server['SERVER_ADDR']]]></code>
     </MixedOperand>
     <MixedReturnStatement>
       <code>$defaults</code>
@@ -415,7 +433,7 @@
       <code>$unencodedUrl</code>
     </MixedReturnStatement>
     <PossiblyFalseOperand>
-      <code>strrpos($host, ':')</code>
+      <code><![CDATA[strrpos($host, ':')]]></code>
     </PossiblyFalseOperand>
   </file>
   <file src="src/functions/normalize_server.legacy.php">
@@ -426,13 +444,13 @@
   </file>
   <file src="src/functions/normalize_server.php">
     <MixedArrayAccess>
-      <code>$apacheRequestHeaders['Authorization']</code>
-      <code>$apacheRequestHeaders['authorization']</code>
+      <code><![CDATA[$apacheRequestHeaders['Authorization']]]></code>
+      <code><![CDATA[$apacheRequestHeaders['authorization']]]></code>
     </MixedArrayAccess>
     <MixedAssignment>
       <code>$apacheRequestHeaders</code>
-      <code>$server['HTTP_AUTHORIZATION']</code>
-      <code>$server['HTTP_AUTHORIZATION']</code>
+      <code><![CDATA[$server['HTTP_AUTHORIZATION']]]></code>
+      <code><![CDATA[$server['HTTP_AUTHORIZATION']]]></code>
     </MixedAssignment>
   </file>
   <file src="src/functions/normalize_uploaded_files.legacy.php">
@@ -460,25 +478,25 @@
                     $nameTree[$key] ?? null,
                     $typeTree[$key] ?? null
                 )</code>
-      <code>$recursiveNormalize(
+      <code><![CDATA[$recursiveNormalize(
             $files['tmp_name'],
             $files['size'],
             $files['error'],
             $files['name'] ?? null,
             $files['type'] ?? null
-        )</code>
+        )]]></code>
     </MixedFunctionCall>
     <MixedInferredReturnType>
       <code>array</code>
     </MixedInferredReturnType>
     <MixedReturnStatement>
-      <code>$recursiveNormalize(
+      <code><![CDATA[$recursiveNormalize(
             $files['tmp_name'],
             $files['size'],
             $files['error'],
             $files['name'] ?? null,
             $files['type'] ?? null
-        )</code>
+        )]]></code>
     </MixedReturnStatement>
   </file>
   <file src="src/functions/parse_cookie_header.legacy.php">
@@ -491,7 +509,7 @@
       <code>$cookies</code>
     </LessSpecificReturnStatement>
     <MoreSpecificReturnType>
-      <code>array&lt;non-empty-string, string&gt;</code>
+      <code><![CDATA[array<non-empty-string, string>]]></code>
     </MoreSpecificReturnType>
   </file>
   <file src="test/CallbackStreamTest.php">
@@ -502,7 +520,7 @@
   </file>
   <file src="test/Integration/UploadedFileTest.php">
     <PossiblyNullArgument>
-      <code>$stream-&gt;getSize()</code>
+      <code><![CDATA[$stream->getSize()]]></code>
     </PossiblyNullArgument>
   </file>
   <file src="test/MessageTraitTest.php">
@@ -547,7 +565,7 @@
       <code>$responseCode</code>
     </MixedAssignment>
     <MoreSpecificReturnType>
-      <code>list&lt;array{numeric-string, non-empty-string}&gt;</code>
+      <code><![CDATA[list<array{numeric-string, non-empty-string}>]]></code>
     </MoreSpecificReturnType>
     <RedundantConditionGivenDocblockType>
       <code>assertIsInt</code>
@@ -558,7 +576,7 @@
   </file>
   <file src="test/ServerRequestFactoryTest.php">
     <InvalidArgument>
-      <code>$normalizedFiles['fooFiles']</code>
+      <code><![CDATA[$normalizedFiles['fooFiles']]]></code>
     </InvalidArgument>
   </file>
   <file src="test/ServerRequestTest.php">
@@ -587,23 +605,23 @@
   </file>
   <file src="test/functions/NormalizeUploadedFilesTest.php">
     <MixedArgument>
-      <code>$normalised['my-form']['details']['avatars']</code>
-      <code>$normalised['slide-shows'][0]['slides']</code>
+      <code><![CDATA[$normalised['my-form']['details']['avatars']]]></code>
+      <code><![CDATA[$normalised['slide-shows'][0]['slides']]]></code>
     </MixedArgument>
     <MixedArrayAccess>
-      <code>$normalised['my-form']['details']['avatar']</code>
-      <code>$normalised['my-form']['details']['avatars']</code>
-      <code>$normalised['my-form']['details']['avatars']</code>
-      <code>$normalised['my-form']['details']['avatars']</code>
-      <code>$normalised['my-form']['details']['avatars']</code>
-      <code>$normalised['my-form']['details']['avatars'][0]</code>
-      <code>$normalised['my-form']['details']['avatars'][1]</code>
-      <code>$normalised['my-form']['details']['avatars'][2]</code>
-      <code>$normalised['slide-shows'][0]['slides']</code>
-      <code>$normalised['slide-shows'][0]['slides']</code>
-      <code>$normalised['slide-shows'][0]['slides']</code>
-      <code>$normalised['slide-shows'][0]['slides'][0]</code>
-      <code>$normalised['slide-shows'][0]['slides'][1]</code>
+      <code><![CDATA[$normalised['my-form']['details']['avatar']]]></code>
+      <code><![CDATA[$normalised['my-form']['details']['avatars']]]></code>
+      <code><![CDATA[$normalised['my-form']['details']['avatars']]]></code>
+      <code><![CDATA[$normalised['my-form']['details']['avatars']]]></code>
+      <code><![CDATA[$normalised['my-form']['details']['avatars']]]></code>
+      <code><![CDATA[$normalised['my-form']['details']['avatars'][0]]]></code>
+      <code><![CDATA[$normalised['my-form']['details']['avatars'][1]]]></code>
+      <code><![CDATA[$normalised['my-form']['details']['avatars'][2]]]></code>
+      <code><![CDATA[$normalised['slide-shows'][0]['slides']]]></code>
+      <code><![CDATA[$normalised['slide-shows'][0]['slides']]]></code>
+      <code><![CDATA[$normalised['slide-shows'][0]['slides']]]></code>
+      <code><![CDATA[$normalised['slide-shows'][0]['slides'][0]]]></code>
+      <code><![CDATA[$normalised['slide-shows'][0]['slides'][1]]]></code>
     </MixedArrayAccess>
     <MixedMethodCall>
       <code>getClientFilename</code>
@@ -614,14 +632,14 @@
       <code>getClientFilename</code>
     </MixedMethodCall>
     <UndefinedInterfaceMethod>
-      <code>$normalised['my-form']</code>
-      <code>$normalised['my-form']</code>
-      <code>$normalised['my-form']</code>
-      <code>$normalised['my-form']</code>
-      <code>$normalised['my-form']</code>
-      <code>$normalised['slide-shows']</code>
-      <code>$normalised['slide-shows']</code>
-      <code>$normalised['slide-shows']</code>
+      <code><![CDATA[$normalised['my-form']]]></code>
+      <code><![CDATA[$normalised['my-form']]]></code>
+      <code><![CDATA[$normalised['my-form']]]></code>
+      <code><![CDATA[$normalised['my-form']]]></code>
+      <code><![CDATA[$normalised['my-form']]]></code>
+      <code><![CDATA[$normalised['slide-shows']]]></code>
+      <code><![CDATA[$normalised['slide-shows']]]></code>
+      <code><![CDATA[$normalised['slide-shows']]]></code>
     </UndefinedInterfaceMethod>
   </file>
 </files>

--- a/test/StreamTest.php
+++ b/test/StreamTest.php
@@ -637,7 +637,7 @@ final class StreamTest extends TestCase
         $stream->attach($resource);
     }
 
-    /** @return CurlHandle|GdImage|Shmop|false */
+    /** @return CurlHandle|GdImage|Shmop|false|resource */
     public function getResourceFor67()
     {
         if (function_exists('curl_init')) {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | yes

### Description

This patch updates the PSR-7 minimum supported version to 1.1. PSR-7 1.1 adds parameter type declarations, but not return type declarations. Since parameters can be widened in implementations, and return types narrowed, our existing implementation (which already features return types) already complies.

For testing, I've pinned this to a branch of the PSR-7 integration test suite submitted as php-http/psr7-integration-tests#68. This ensures that we fulfill the changed expectations (raising either `InvalidArgumentException` OR `TypeError` for invalid parameters), and will not need to update again once we prepare a v3 release of this library that explicitly adds parameter type declarations.

After updating dependencies, Psalm flagged a number of issues. I corrected one that was easily corrected; the remainder are due to Psalm detecting the parent parameter type declarations and deciding we don't need to do some of our validations. Since at runtime, invalid data could still be passed to the implementation, I've pushed these into the Psalm baseline for now, and for removal once we prepare for v3 targeting PSR-7 v2.
