### PR TITLE
Disallow cloning Stream objects

### DIFF
--- a/src/Stream.php
+++ b/src/Stream.php
@@ -364,4 +364,11 @@ class Stream implements StreamInterface, Stringable
 
         return false;
     }
+
+    /**
+     * Disallow stream cloning.
+     */
+    private function __clone()
+    {
+    }
 }

--- a/test/StreamTest.php
+++ b/test/StreamTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LaminasTest\Diactoros;
 
 use CurlHandle;
+use Error;
 use GdImage;
 use InvalidArgumentException;
 use Laminas\Diactoros\Stream;
@@ -678,5 +679,19 @@ final class StreamTest extends TestCase
         $resource = fopen('php://input', 'r');
         $stream   = new Stream($resource);
         $this->assertNull($stream->getSize());
+    }
+
+    public function testStreamsAreUnclonable(): void
+    {
+        $stream = new Stream(fopen('php://temp', 'r+'));
+        $stream->write('foo');
+
+        $this->assertSame('foo', $stream->__toString());
+
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage('private Laminas\Diactoros\Stream::__clone()');
+
+        /** @psalm-suppress InvalidClone */
+        clone $stream;
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | ?
| BC Break      | ?
| New Feature   | no
| RFC           | yes
| QA            | no

### Description

Not necessarily intended to be merged, primarily intended to put this up for discussion with an actual code change instead of just raising an issue. I did not encounter this in a real-world app, this was more of a “what if”.

------------

Streams hold a reference to the stateful resource handle for their actual contents. Cloning a Stream will not actually clone the underlying resource, thus both streams would still refer to the same resource after cloning and any changes in one stream object would be reflected in the other object. This violates user expectations after a cloning operation.

Disallow cloning entirely as the safe default choice. Alternatively a new stream could be created and attached and the contents could be copied over. This can get expensive with larger or infinite streams, though.

