### PR TITLE
ImageStream implementation

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -28,6 +28,17 @@
       <code>__construct</code>
     </UnusedConstructor>
   </file>
+  <file src="src/ImageStream.php">
+    <ImplementedReturnTypeMismatch>
+      <code>null|GdImage</code>
+    </ImplementedReturnTypeMismatch>
+    <MoreSpecificImplementedParamType>
+      <code>$resource</code>
+    </MoreSpecificImplementedParamType>
+    <NonInvariantDocblockPropertyType>
+      <code>$resource</code>
+    </NonInvariantDocblockPropertyType>
+  </file>
   <file src="src/MessageTrait.php">
     <DocblockTypeContradiction>
       <code>! is_string($name)</code>
@@ -101,7 +112,7 @@
       <code>$protocolVersion</code>
       <code>$requestTarget</code>
       <code>$uri</code>
-      <code>self::getValueFromKey($serializedRequest, 'body')</code>
+      <code><![CDATA[self::getValueFromKey($serializedRequest, 'body')]]></code>
     </MixedArgument>
     <MixedAssignment>
       <code>$headers</code>
@@ -154,7 +165,7 @@
       <code>$protocolVersion</code>
       <code>$reasonPhrase</code>
       <code>$statusCode</code>
-      <code>self::getValueFromKey($serializedResponse, 'body')</code>
+      <code><![CDATA[self::getValueFromKey($serializedResponse, 'body')]]></code>
     </MixedArgument>
     <MixedAssignment>
       <code>$headers</code>
@@ -230,7 +241,7 @@
   </file>
   <file src="src/ServerRequestFactory.php">
     <LessSpecificReturnStatement>
-      <code>$requestFilter(new ServerRequest(
+      <code><![CDATA[$requestFilter(new ServerRequest(
             $server,
             $files,
             UriFactory::createFromSapi($server, $headers),
@@ -241,10 +252,10 @@
             $query ?: $_GET,
             $body ?: $_POST,
             marshalProtocolVersionFromSapi($server)
-        ))</code>
+        ))]]></code>
     </LessSpecificReturnStatement>
     <MixedArgument>
-      <code>$headers['cookie']</code>
+      <code><![CDATA[$headers['cookie']]]></code>
     </MixedArgument>
     <MixedArgumentTypeCoercion>
       <code>$headers</code>
@@ -365,10 +376,10 @@
   </file>
   <file src="src/functions/create_uploaded_file.php">
     <MixedArgument>
-      <code>$spec['error']</code>
-      <code>$spec['name'] ?? null</code>
-      <code>$spec['tmp_name']</code>
-      <code>$spec['type'] ?? null</code>
+      <code><![CDATA[$spec['error']]]></code>
+      <code><![CDATA[$spec['name'] ?? null]]></code>
+      <code><![CDATA[$spec['tmp_name']]]></code>
+      <code><![CDATA[$spec['type'] ?? null]]></code>
     </MixedArgument>
   </file>
   <file src="src/functions/marshal_headers_from_sapi.legacy.php">
@@ -393,8 +404,8 @@
       <code>string</code>
     </MixedInferredReturnType>
     <MixedReturnStatement>
-      <code>$server['REQUEST_METHOD'] ?? 'GET'</code>
-      <code>$server['REQUEST_METHOD'] ?? 'GET'</code>
+      <code><![CDATA[$server['REQUEST_METHOD'] ?? 'GET']]></code>
+      <code><![CDATA[$server['REQUEST_METHOD'] ?? 'GET']]></code>
     </MixedReturnStatement>
   </file>
   <file src="src/functions/marshal_protocol_version_from_sapi.legacy.php">
@@ -404,7 +415,7 @@
   </file>
   <file src="src/functions/marshal_protocol_version_from_sapi.php">
     <MixedArgument>
-      <code>$server['SERVER_PROTOCOL']</code>
+      <code><![CDATA[$server['SERVER_PROTOCOL']]]></code>
     </MixedArgument>
   </file>
   <file src="src/functions/marshal_uri_from_sapi.legacy.php">
@@ -424,14 +435,14 @@
       <code>static function (string $name, array $headers, $default = null) {</code>
     </MissingClosureReturnType>
     <MixedArgument>
-      <code>$getHeaderFromArray('x-forwarded-proto', $headers, '')</code>
+      <code><![CDATA[$getHeaderFromArray('x-forwarded-proto', $headers, '')]]></code>
       <code>$host</code>
       <code>$host</code>
       <code>$host</code>
       <code>$host</code>
       <code>$port</code>
       <code>$requestUri</code>
-      <code>$server['QUERY_STRING']</code>
+      <code><![CDATA[$server['QUERY_STRING']]]></code>
     </MixedArgument>
     <MixedArgumentTypeCoercion>
       <code>$headers[$header]</code>
@@ -448,7 +459,7 @@
       <code>string</code>
     </MixedInferredReturnType>
     <MixedOperand>
-      <code>$server['SERVER_ADDR']</code>
+      <code><![CDATA[$server['SERVER_ADDR']]]></code>
     </MixedOperand>
     <MixedReturnStatement>
       <code>$defaults</code>
@@ -456,7 +467,7 @@
       <code>$unencodedUrl</code>
     </MixedReturnStatement>
     <PossiblyFalseOperand>
-      <code>strrpos($host, ':')</code>
+      <code><![CDATA[strrpos($host, ':')]]></code>
     </PossiblyFalseOperand>
   </file>
   <file src="src/functions/normalize_server.legacy.php">
@@ -467,13 +478,13 @@
   </file>
   <file src="src/functions/normalize_server.php">
     <MixedArrayAccess>
-      <code>$apacheRequestHeaders['Authorization']</code>
-      <code>$apacheRequestHeaders['authorization']</code>
+      <code><![CDATA[$apacheRequestHeaders['Authorization']]]></code>
+      <code><![CDATA[$apacheRequestHeaders['authorization']]]></code>
     </MixedArrayAccess>
     <MixedAssignment>
       <code>$apacheRequestHeaders</code>
-      <code>$server['HTTP_AUTHORIZATION']</code>
-      <code>$server['HTTP_AUTHORIZATION']</code>
+      <code><![CDATA[$server['HTTP_AUTHORIZATION']]]></code>
+      <code><![CDATA[$server['HTTP_AUTHORIZATION']]]></code>
     </MixedAssignment>
   </file>
   <file src="src/functions/normalize_uploaded_files.legacy.php">
@@ -501,25 +512,25 @@
                     $nameTree[$key] ?? null,
                     $typeTree[$key] ?? null
                 )</code>
-      <code>$recursiveNormalize(
+      <code><![CDATA[$recursiveNormalize(
             $files['tmp_name'],
             $files['size'],
             $files['error'],
             $files['name'] ?? null,
             $files['type'] ?? null
-        )</code>
+        )]]></code>
     </MixedFunctionCall>
     <MixedInferredReturnType>
       <code>array</code>
     </MixedInferredReturnType>
     <MixedReturnStatement>
-      <code>$recursiveNormalize(
+      <code><![CDATA[$recursiveNormalize(
             $files['tmp_name'],
             $files['size'],
             $files['error'],
             $files['name'] ?? null,
             $files['type'] ?? null
-        )</code>
+        )]]></code>
     </MixedReturnStatement>
   </file>
   <file src="src/functions/parse_cookie_header.legacy.php">
@@ -540,6 +551,11 @@
       <code>$ret</code>
       <code>$ret</code>
     </MixedAssignment>
+  </file>
+  <file src="test/ImageStreamTest.php">
+    <InvalidArgument>
+      <code>$resourceToAttach</code>
+    </InvalidArgument>
   </file>
   <file src="test/Integration/UploadedFileTest.php">
     <PossiblyNullArgument>
@@ -599,7 +615,7 @@
   </file>
   <file src="test/ServerRequestFactoryTest.php">
     <InvalidArgument>
-      <code>$normalizedFiles['fooFiles']</code>
+      <code><![CDATA[$normalizedFiles['fooFiles']]]></code>
     </InvalidArgument>
   </file>
   <file src="test/ServerRequestTest.php">
@@ -650,23 +666,23 @@
   </file>
   <file src="test/functions/NormalizeUploadedFilesTest.php">
     <MixedArgument>
-      <code>$normalised['my-form']['details']['avatars']</code>
-      <code>$normalised['slide-shows'][0]['slides']</code>
+      <code><![CDATA[$normalised['my-form']['details']['avatars']]]></code>
+      <code><![CDATA[$normalised['slide-shows'][0]['slides']]]></code>
     </MixedArgument>
     <MixedArrayAccess>
-      <code>$normalised['my-form']['details']['avatar']</code>
-      <code>$normalised['my-form']['details']['avatars']</code>
-      <code>$normalised['my-form']['details']['avatars']</code>
-      <code>$normalised['my-form']['details']['avatars']</code>
-      <code>$normalised['my-form']['details']['avatars']</code>
-      <code>$normalised['my-form']['details']['avatars'][0]</code>
-      <code>$normalised['my-form']['details']['avatars'][1]</code>
-      <code>$normalised['my-form']['details']['avatars'][2]</code>
-      <code>$normalised['slide-shows'][0]['slides']</code>
-      <code>$normalised['slide-shows'][0]['slides']</code>
-      <code>$normalised['slide-shows'][0]['slides']</code>
-      <code>$normalised['slide-shows'][0]['slides'][0]</code>
-      <code>$normalised['slide-shows'][0]['slides'][1]</code>
+      <code><![CDATA[$normalised['my-form']['details']['avatar']]]></code>
+      <code><![CDATA[$normalised['my-form']['details']['avatars']]]></code>
+      <code><![CDATA[$normalised['my-form']['details']['avatars']]]></code>
+      <code><![CDATA[$normalised['my-form']['details']['avatars']]]></code>
+      <code><![CDATA[$normalised['my-form']['details']['avatars']]]></code>
+      <code><![CDATA[$normalised['my-form']['details']['avatars'][0]]]></code>
+      <code><![CDATA[$normalised['my-form']['details']['avatars'][1]]]></code>
+      <code><![CDATA[$normalised['my-form']['details']['avatars'][2]]]></code>
+      <code><![CDATA[$normalised['slide-shows'][0]['slides']]]></code>
+      <code><![CDATA[$normalised['slide-shows'][0]['slides']]]></code>
+      <code><![CDATA[$normalised['slide-shows'][0]['slides']]]></code>
+      <code><![CDATA[$normalised['slide-shows'][0]['slides'][0]]]></code>
+      <code><![CDATA[$normalised['slide-shows'][0]['slides'][1]]]></code>
     </MixedArrayAccess>
     <MixedMethodCall>
       <code>getClientFilename</code>
@@ -677,14 +693,14 @@
       <code>getClientFilename</code>
     </MixedMethodCall>
     <UndefinedInterfaceMethod>
-      <code>$normalised['my-form']</code>
-      <code>$normalised['my-form']</code>
-      <code>$normalised['my-form']</code>
-      <code>$normalised['my-form']</code>
-      <code>$normalised['my-form']</code>
-      <code>$normalised['slide-shows']</code>
-      <code>$normalised['slide-shows']</code>
-      <code>$normalised['slide-shows']</code>
+      <code><![CDATA[$normalised['my-form']]]></code>
+      <code><![CDATA[$normalised['my-form']]]></code>
+      <code><![CDATA[$normalised['my-form']]]></code>
+      <code><![CDATA[$normalised['my-form']]]></code>
+      <code><![CDATA[$normalised['my-form']]]></code>
+      <code><![CDATA[$normalised['slide-shows']]]></code>
+      <code><![CDATA[$normalised['slide-shows']]]></code>
+      <code><![CDATA[$normalised['slide-shows']]]></code>
     </UndefinedInterfaceMethod>
   </file>
 </files>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -632,6 +632,9 @@
     <DeprecatedMethod>
       <code>setMethods</code>
     </DeprecatedMethod>
+    <UnusedClosureParam>
+      <code>$errno</code>
+    </UnusedClosureParam>
   </file>
   <file src="test/TestAsset/CallbacksForCallbackStreamTest.php">
     <PossiblyUnusedMethod>

--- a/src/ImageStream.php
+++ b/src/ImageStream.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Diactoros;
+
+use GdImage;
+
+use function sprintf;
+
+/**
+ * This class purposely does not override the $resource property in order to
+ * allow it to extend Stream. If defined here with a type, PHP will raise a
+ * fatal error complaining that it must not define a type for the property.
+ */
+class ImageStream extends Stream
+{
+    /**
+     * This purposely does not explicitly override the $resource property in
+     * order to allow it to extend Stream. If defined here with a type, PHP will
+     * raise a fatal error complaining that it must not define a type for the
+     * property.
+     *
+     * @var null|GdImage
+     */
+    protected $resource;
+
+    public function __construct(
+        GdImage $resource,
+    ) {
+        $this->resource = $resource;
+    }
+
+    /**
+     * {@inheritdoc}
+     * @return null|GdImage
+     */
+    public function detach(): ?GdImage
+    {
+        $resource       = $this->resource;
+        $this->resource = null;
+        return $resource;
+    }
+
+    /**
+     * Attach a new stream/resource to the instance.
+     *
+     * @param GdImage $resource
+     * @param string $mode Unused
+     * @throws Exception\InvalidArgumentException When provided a non-GdImage resource.
+     */
+    public function attach($resource, string $mode = 'r'): void
+    {
+        if (! $resource instanceof GdImage) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'When attaching a resource to %s, resource must be a GdImage',
+                $this::class,
+            ));
+        }
+
+        $this->resource = $resource;
+    }
+}

--- a/src/ImageStream.php
+++ b/src/ImageStream.php
@@ -33,6 +33,7 @@ class ImageStream extends Stream
 
     /**
      * {@inheritdoc}
+     *
      * @return null|GdImage
      */
     public function detach(): ?GdImage

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -28,7 +28,9 @@ use function sprintf;
 use function stream_get_contents;
 use function stream_get_meta_data;
 use function strstr;
+use function trigger_error;
 
+use const E_USER_DEPRECATED;
 use const SEEK_SET;
 
 /**
@@ -359,6 +361,14 @@ class Stream implements StreamInterface, Stringable
         }
 
         if ($resource instanceof GdImage) {
+            trigger_error(
+                sprintf(
+                    'When using GdImage resources, use %s; %s will drop support for GdImage in 3.0.0',
+                    ImageStream::class,
+                    self::class
+                ),
+                E_USER_DEPRECATED,
+            );
             return true;
         }
 

--- a/src/StreamFactory.php
+++ b/src/StreamFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\Diactoros;
 
+use GdImage;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 
@@ -35,9 +36,15 @@ class StreamFactory implements StreamFactoryInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @param resource|GdImage $resource
      */
     public function createStreamFromResource($resource): StreamInterface
     {
+        if ($resource instanceof GdImage) {
+            return new ImageStream($resource);
+        }
+
         return new Stream($resource);
     }
 }

--- a/test/ImageStreamTest.php
+++ b/test/ImageStreamTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Diactoros;
+
+use GdImage;
+use Laminas\Diactoros\Exception\InvalidArgumentException;
+use Laminas\Diactoros\ImageStream;
+use Laminas\Diactoros\Stream;
+use PHPUnit\Framework\TestCase;
+
+use function assert;
+use function fopen;
+use function imagecreate;
+
+class ImageStreamTest extends TestCase
+{
+    public function testCanInstantiateWithGDResource(): ImageStream
+    {
+        $resource = imagecreate(1, 1);
+        $stream   = new ImageStream($resource);
+        $this->assertInstanceOf(ImageStream::class, $stream);
+
+        return $stream;
+    }
+
+    /** @depends testCanInstantiateWithGDResource */
+    public function testImageStreamExtendsStream(ImageStream $stream): void
+    {
+        $this->assertInstanceOf(Stream::class, $stream);
+    }
+
+    public function testDetachReturnsGDResource(): void
+    {
+        $resource = imagecreate(1, 1);
+        assert($resource instanceof GdImage);
+        $stream   = new ImageStream($resource);
+        $detached = $stream->detach();
+
+        $this->assertInstanceOf(GdImage::class, $detached);
+        $this->assertSame($resource, $detached);
+    }
+
+    /** @psalm-return non-empty-array<non-empty-string, array{resource}> */
+    public function invalidResourceProvider(): array
+    {
+        return [
+            'file' => [fopen(__FILE__, 'r')],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidResourceProvider
+     * @param resource $resourceToAttach
+     */
+    public function testAttachRaisesExceptionForNonGDResource($resourceToAttach): void
+    {
+        $resource = imagecreate(1, 1);
+        assert($resource instanceof GdImage);
+
+        $stream = new ImageStream($resource);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('resource must be a GdImage');
+        $stream->attach($resourceToAttach);
+    }
+
+    public function testAttachSwitchesToNewResourceWhenSuccessful(): void
+    {
+        $resource1 = imagecreate(1, 1);
+        assert($resource1 instanceof GdImage);
+        $resource2 = imagecreate(1, 1);
+        assert($resource2 instanceof GdImage);
+
+        $stream = new ImageStream($resource1);
+        $stream->attach($resource2);
+
+        $detached = $stream->detach();
+
+        $this->assertInstanceOf(GdImage::class, $detached);
+        $this->assertSame($resource2, $detached);
+    }
+}

--- a/test/StreamFactoryTest.php
+++ b/test/StreamFactoryTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Diactoros;
+
+use GdImage;
+use Laminas\Diactoros\ImageStream;
+use Laminas\Diactoros\Stream;
+use Laminas\Diactoros\StreamFactory;
+use PHPUnit\Framework\TestCase;
+
+use function assert;
+use function fopen;
+use function imagecreate;
+
+class StreamFactoryTest extends TestCase
+{
+    public function testPassingGdImageToCreateStreamFromResourceReturnsImageStream(): void
+    {
+        $factory  = new StreamFactory();
+        $resource = imagecreate(1, 1);
+        assert($resource instanceof GdImage);
+
+        $stream = $factory->createStreamFromResource($resource);
+        $this->assertInstanceOf(ImageStream::class, $stream);
+    }
+
+    public function testPassingFileResourceToCreateStreamFromResourceReturnsStream(): void
+    {
+        $factory  = new StreamFactory();
+        $resource = fopen(__FILE__, 'r');
+        $stream   = $factory->createStreamFromResource($resource);
+        $this->assertInstanceOf(Stream::class, $stream);
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | future
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

Per discussion in #57, this patch does the following:

- Introduces the `ImageStream` class as an extension of `Stream` that only works with `GdImage` resources.
- Updates `Stream` to emit an `E_USER_DEPRECATED` error when used with a `GdImage` resource, pointing users to the new `ImageStream` implementation.
- Updates `StreamFactory::createStreamFromResource()` to detect `GdImage` resources, and to create and return an `ImageStream` when it does.

The plan will be for 3.0.0 to remove support for `GdImage` from `Stream`.
