### PR TITLE
Allow numeric header names

### DIFF
--- a/docs/book/v3/migration.md
+++ b/docs/book/v3/migration.md
@@ -9,6 +9,15 @@ The following features were changed in version 3.
 The factory `Laminas\Diactoros\ServerRequestFactory::fromGlobals()` was modified such that passing empty array values for arguments that accept `null` or an array now will not use the associated superglobal in that scenario.
 Previously, an empty array value was treated as identical to `null`, and would cause the factory to fallback to superglobals; now, this is a way to provide an empty set for the associated value(s).
 
+### HeaderSecurity::assertValidName behavior
+
+Since it was introduced, `Laminas\Diactoros\HeaderSecurity::assertValidName()`, used in both request and response classes to validate header names, has considered numeric headers invalid.
+However [RFC 7230 Section 3.2.6](https://www.rfc-editor.org/rfc/rfc7230#section-3.2.6) illustrates that numeric values are allowed as header names.
+Unfortunately, the behavior of the PHP engine itself is such that string keys that contain integer values are cast to an integer, which would then cause this method to flag a header as invalid.
+
+Version 3 loosens the logic slightly, adding a check for a non-string, non-numeric value first.
+If the value is numeric, it is cast to a string, and then checked against a regular expression that matches the RFC 7230 ABNF for valid header values. This will allow float and integer values to be used as header names.
+
 ## Removed
 
 The following features were removed for version 3.

--- a/docs/book/v3/migration.md
+++ b/docs/book/v3/migration.md
@@ -11,12 +11,13 @@ Previously, an empty array value was treated as identical to `null`, and would c
 
 ### HeaderSecurity::assertValidName behavior
 
-Since it was introduced, `Laminas\Diactoros\HeaderSecurity::assertValidName()`, used in both request and response classes to validate header names, has considered numeric headers invalid.
+Since it was introduced, `Laminas\Diactoros\HeaderSecurity::assertValidName()`, used in both request and response classes to validate header names, has considered integer headers invalid.
 However [RFC 7230 Section 3.2.6](https://www.rfc-editor.org/rfc/rfc7230#section-3.2.6) illustrates that numeric values are allowed as header names.
 Unfortunately, the behavior of the PHP engine itself is such that string keys that contain integer values are cast to an integer, which would then cause this method to flag a header as invalid.
 
-Version 3 loosens the logic slightly, adding a check for a non-string, non-numeric value first.
-If the value is numeric, it is cast to a string, and then checked against a regular expression that matches the RFC 7230 ABNF for valid header values. This will allow float and integer values to be used as header names.
+Version 3 loosens the logic slightly, adding a check for a non-string, non-integer value first.
+If the value is an integer, it is cast to a string, and then checked against a regular expression that matches the RFC 7230 ABNF for valid header values.
+This allows integer values to be used as header names.
 
 ## Removed
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -46,20 +46,17 @@
       <code>$header</code>
       <code>$header</code>
       <code>$header</code>
-      <code>$header</code>
     </MixedArgumentTypeCoercion>
     <MixedAssignment>
       <code>$v</code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedPropertyTypeCoercion>
-      <code>$headers</code>
-    </MixedPropertyTypeCoercion>
     <ParamNameMismatch>
       <code>$header</code>
       <code>$header</code>
     </ParamNameMismatch>
     <PropertyTypeCoercion>
+      <code>$headers</code>
       <code><![CDATA[$new->headerNames]]></code>
       <code><![CDATA[$new->headers]]></code>
     </PropertyTypeCoercion>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -49,6 +49,7 @@
       <code>$header</code>
     </MixedArgumentTypeCoercion>
     <MixedAssignment>
+      <code>$v</code>
       <code>$value</code>
     </MixedAssignment>
     <MixedPropertyTypeCoercion>
@@ -62,6 +63,9 @@
       <code><![CDATA[$new->headerNames]]></code>
       <code><![CDATA[$new->headers]]></code>
     </PropertyTypeCoercion>
+    <UnusedForeachValue>
+      <code>$v</code>
+    </UnusedForeachValue>
   </file>
   <file src="src/Module.php">
     <UnusedClass>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -51,6 +51,9 @@
       <code>$v</code>
       <code>$value</code>
     </MixedAssignment>
+    <MixedInferredReturnType>
+      <code>bool</code>
+    </MixedInferredReturnType>
     <ParamNameMismatch>
       <code>$header</code>
       <code>$header</code>
@@ -81,7 +84,7 @@
       <code>$protocolVersion</code>
       <code>$requestTarget</code>
       <code>$uri</code>
-      <code><![CDATA[self::getValueFromKey($serializedRequest, 'body')]]></code>
+      <code>self::getValueFromKey($serializedRequest, 'body')</code>
     </MixedArgument>
     <MixedAssignment>
       <code>$headers</code>
@@ -115,7 +118,7 @@
       <code>$protocolVersion</code>
       <code>$reasonPhrase</code>
       <code>$statusCode</code>
-      <code><![CDATA[self::getValueFromKey($serializedResponse, 'body')]]></code>
+      <code>self::getValueFromKey($serializedResponse, 'body')</code>
     </MixedArgument>
     <MixedAssignment>
       <code>$headers</code>
@@ -187,7 +190,7 @@
   </file>
   <file src="src/ServerRequestFactory.php">
     <MixedArgument>
-      <code><![CDATA[$headers['cookie']]]></code>
+      <code>$headers['cookie']</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion>
       <code>$headers</code>
@@ -251,10 +254,10 @@
   </file>
   <file src="src/functions/create_uploaded_file.php">
     <MixedArgument>
-      <code><![CDATA[$spec['error']]]></code>
-      <code><![CDATA[$spec['name'] ?? null]]></code>
-      <code><![CDATA[$spec['tmp_name']]]></code>
-      <code><![CDATA[$spec['type'] ?? null]]></code>
+      <code>$spec['error']</code>
+      <code>$spec['name'] ?? null</code>
+      <code>$spec['tmp_name']</code>
+      <code>$spec['type'] ?? null</code>
     </MixedArgument>
   </file>
   <file src="src/functions/marshal_headers_from_sapi.php">
@@ -269,24 +272,24 @@
       <code>string</code>
     </MixedInferredReturnType>
     <MixedReturnStatement>
-      <code><![CDATA[$server['REQUEST_METHOD'] ?? 'GET']]></code>
-      <code><![CDATA[$server['REQUEST_METHOD'] ?? 'GET']]></code>
+      <code>$server['REQUEST_METHOD'] ?? 'GET'</code>
+      <code>$server['REQUEST_METHOD'] ?? 'GET'</code>
     </MixedReturnStatement>
   </file>
   <file src="src/functions/marshal_protocol_version_from_sapi.php">
     <MixedArgument>
-      <code><![CDATA[$server['SERVER_PROTOCOL']]]></code>
+      <code>$server['SERVER_PROTOCOL']</code>
     </MixedArgument>
   </file>
   <file src="src/functions/normalize_server.php">
     <MixedArrayAccess>
-      <code><![CDATA[$apacheRequestHeaders['Authorization']]]></code>
-      <code><![CDATA[$apacheRequestHeaders['authorization']]]></code>
+      <code>$apacheRequestHeaders['Authorization']</code>
+      <code>$apacheRequestHeaders['authorization']</code>
     </MixedArrayAccess>
     <MixedAssignment>
       <code>$apacheRequestHeaders</code>
-      <code><![CDATA[$server['HTTP_AUTHORIZATION']]]></code>
-      <code><![CDATA[$server['HTTP_AUTHORIZATION']]]></code>
+      <code>$server['HTTP_AUTHORIZATION']</code>
+      <code>$server['HTTP_AUTHORIZATION']</code>
     </MixedAssignment>
   </file>
   <file src="src/functions/normalize_uploaded_files.php">
@@ -309,25 +312,25 @@
                     $nameTree[$key] ?? null,
                     $typeTree[$key] ?? null
                 )</code>
-      <code><![CDATA[$recursiveNormalize(
+      <code>$recursiveNormalize(
             $files['tmp_name'],
             $files['size'],
             $files['error'],
             $files['name'] ?? null,
             $files['type'] ?? null
-        )]]></code>
+        )</code>
     </MixedFunctionCall>
     <MixedInferredReturnType>
       <code>array</code>
     </MixedInferredReturnType>
     <MixedReturnStatement>
-      <code><![CDATA[$recursiveNormalize(
+      <code>$recursiveNormalize(
             $files['tmp_name'],
             $files['size'],
             $files['error'],
             $files['name'] ?? null,
             $files['type'] ?? null
-        )]]></code>
+        )</code>
     </MixedReturnStatement>
   </file>
   <file src="src/functions/parse_cookie_header.php">
@@ -387,7 +390,7 @@
   </file>
   <file src="test/ServerRequestFactoryTest.php">
     <InvalidArgument>
-      <code><![CDATA[$normalizedFiles['fooFiles']]]></code>
+      <code>$normalizedFiles['fooFiles']</code>
     </InvalidArgument>
   </file>
   <file src="test/ServerRequestTest.php">
@@ -435,23 +438,23 @@
   </file>
   <file src="test/functions/NormalizeUploadedFilesTest.php">
     <MixedArgument>
-      <code><![CDATA[$normalised['my-form']['details']['avatars']]]></code>
-      <code><![CDATA[$normalised['slide-shows'][0]['slides']]]></code>
+      <code>$normalised['my-form']['details']['avatars']</code>
+      <code>$normalised['slide-shows'][0]['slides']</code>
     </MixedArgument>
     <MixedArrayAccess>
-      <code><![CDATA[$normalised['my-form']['details']['avatar']]]></code>
-      <code><![CDATA[$normalised['my-form']['details']['avatars']]]></code>
-      <code><![CDATA[$normalised['my-form']['details']['avatars']]]></code>
-      <code><![CDATA[$normalised['my-form']['details']['avatars']]]></code>
-      <code><![CDATA[$normalised['my-form']['details']['avatars']]]></code>
-      <code><![CDATA[$normalised['my-form']['details']['avatars'][0]]]></code>
-      <code><![CDATA[$normalised['my-form']['details']['avatars'][1]]]></code>
-      <code><![CDATA[$normalised['my-form']['details']['avatars'][2]]]></code>
-      <code><![CDATA[$normalised['slide-shows'][0]['slides']]]></code>
-      <code><![CDATA[$normalised['slide-shows'][0]['slides']]]></code>
-      <code><![CDATA[$normalised['slide-shows'][0]['slides']]]></code>
-      <code><![CDATA[$normalised['slide-shows'][0]['slides'][0]]]></code>
-      <code><![CDATA[$normalised['slide-shows'][0]['slides'][1]]]></code>
+      <code>$normalised['my-form']['details']['avatar']</code>
+      <code>$normalised['my-form']['details']['avatars']</code>
+      <code>$normalised['my-form']['details']['avatars']</code>
+      <code>$normalised['my-form']['details']['avatars']</code>
+      <code>$normalised['my-form']['details']['avatars']</code>
+      <code>$normalised['my-form']['details']['avatars'][0]</code>
+      <code>$normalised['my-form']['details']['avatars'][1]</code>
+      <code>$normalised['my-form']['details']['avatars'][2]</code>
+      <code>$normalised['slide-shows'][0]['slides']</code>
+      <code>$normalised['slide-shows'][0]['slides']</code>
+      <code>$normalised['slide-shows'][0]['slides']</code>
+      <code>$normalised['slide-shows'][0]['slides'][0]</code>
+      <code>$normalised['slide-shows'][0]['slides'][1]</code>
     </MixedArrayAccess>
     <MixedMethodCall>
       <code>getClientFilename</code>
@@ -462,14 +465,14 @@
       <code>getClientFilename</code>
     </MixedMethodCall>
     <UndefinedInterfaceMethod>
-      <code><![CDATA[$normalised['my-form']]]></code>
-      <code><![CDATA[$normalised['my-form']]]></code>
-      <code><![CDATA[$normalised['my-form']]]></code>
-      <code><![CDATA[$normalised['my-form']]]></code>
-      <code><![CDATA[$normalised['my-form']]]></code>
-      <code><![CDATA[$normalised['slide-shows']]]></code>
-      <code><![CDATA[$normalised['slide-shows']]]></code>
-      <code><![CDATA[$normalised['slide-shows']]]></code>
+      <code>$normalised['my-form']</code>
+      <code>$normalised['my-form']</code>
+      <code>$normalised['my-form']</code>
+      <code>$normalised['my-form']</code>
+      <code>$normalised['my-form']</code>
+      <code>$normalised['slide-shows']</code>
+      <code>$normalised['slide-shows']</code>
+      <code>$normalised['slide-shows']</code>
     </UndefinedInterfaceMethod>
   </file>
 </files>

--- a/src/AbstractSerializer.php
+++ b/src/AbstractSerializer.php
@@ -8,6 +8,7 @@ use Psr\Http\Message\StreamInterface;
 
 use function array_pop;
 use function implode;
+use function is_int;
 use function preg_match;
 use function sprintf;
 use function str_replace;
@@ -137,11 +138,12 @@ abstract class AbstractSerializer
     /**
      * Filter a header name to wordcase
      *
-     * @param string $header
+     * @param string|int $header
      */
     protected static function filterHeader($header): string
     {
-        $filtered = str_replace('-', ' ', $header);
+        $filtered = is_int($header) ? (string) $header : $header;
+        $filtered = str_replace('-', ' ', $filtered);
         $filtered = ucwords($filtered);
         return str_replace(' ', '-', $filtered);
     }

--- a/src/HeaderSecurity.php
+++ b/src/HeaderSecurity.php
@@ -148,16 +148,16 @@ final class HeaderSecurity
      */
     public static function assertValidName(mixed $name): void
     {
-        if (! is_string($name)) {
+        if (! is_string($name) && ! is_numeric($name)) {
             throw new Exception\InvalidArgumentException(sprintf(
-                'Invalid header name type; expected string; received %s',
+                'Invalid header name type; expected string or numeric value; received %s',
                 is_object($name) ? $name::class : gettype($name)
             ));
         }
-        if (! preg_match('/^[a-zA-Z0-9\'`#$%&*+.^_|~!-]+$/D', $name)) {
+        if (! preg_match('/^[a-zA-Z0-9\'`#$%&*+.^_|~!-]+$/D', (string) $name)) {
             throw new Exception\InvalidArgumentException(sprintf(
                 '"%s" is not valid header name',
-                $name
+                (string) $name
             ));
         }
     }

--- a/src/HeaderSecurity.php
+++ b/src/HeaderSecurity.php
@@ -6,6 +6,7 @@ namespace Laminas\Diactoros;
 
 use function gettype;
 use function in_array;
+use function is_int;
 use function is_numeric;
 use function is_object;
 use function is_string;
@@ -148,16 +149,19 @@ final class HeaderSecurity
      */
     public static function assertValidName(mixed $name): void
     {
-        if (! is_string($name) && ! is_numeric($name)) {
+        if (! is_string($name) && ! is_int($name)) {
             throw new Exception\InvalidArgumentException(sprintf(
-                'Invalid header name type; expected string or numeric value; received %s',
+                'Invalid header name type; expected string or integer value; received %s',
                 is_object($name) ? $name::class : gettype($name)
             ));
         }
-        if (! preg_match('/^[a-zA-Z0-9\'`#$%&*+.^_|~!-]+$/D', (string) $name)) {
+
+        $name = is_int($name) ? (string) $name : $name;
+
+        if (! preg_match('/^[a-zA-Z0-9\'`#$%&*+.^_|~!-]+$/D', $name)) {
             throw new Exception\InvalidArgumentException(sprintf(
                 '"%s" is not valid header name',
-                (string) $name
+                $name
             ));
         }
     }

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -7,9 +7,11 @@ namespace Laminas\Diactoros;
 use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\StreamInterface;
 
+use function array_is_list;
 use function array_map;
 use function array_merge;
 use function array_values;
+use function function_exists;
 use function implode;
 use function is_array;
 use function is_resource;
@@ -327,6 +329,10 @@ trait MessageTrait
      */
     private function setHeaders(array $originalHeaders): void
     {
+        if ($this->arrayIsList($originalHeaders)) {
+            throw new Exception\InvalidArgumentException('Header array must be an associative array');
+        }
+
         $headerNames = $headers = [];
 
         foreach ($originalHeaders as $header => $value) {
@@ -340,6 +346,27 @@ trait MessageTrait
 
         $this->headerNames = $headerNames;
         $this->headers     = $headers;
+    }
+
+    /**
+     * @todo Replace this method with a call to ! empty($array) &&
+     *     array_is_list once minimum PHP version is 8.1.
+     */
+    private function arrayIsList(array $array): bool
+    {
+        if (function_exists('array_is_list')) {
+            return ! empty($array) && array_is_list($array);
+        }
+
+        $i = -1;
+        foreach ($array as $k => $v) {
+            ++$i;
+            if ($k !== $i) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -356,8 +356,12 @@ trait MessageTrait
      */
     private function arrayIsList(array $array): bool
     {
+        if (empty($array)) {
+            return false;
+        }
+
         if (function_exists('array_is_list')) {
-            return ! empty($array) && array_is_list($array);
+            return array_is_list($array);
         }
 
         $i = -1;

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -14,6 +14,7 @@ use function array_values;
 use function function_exists;
 use function implode;
 use function is_array;
+use function is_int;
 use function is_resource;
 use function is_string;
 use function preg_match;
@@ -33,7 +34,7 @@ trait MessageTrait
      * List of all registered headers, as key => array of values.
      *
      * @var array
-     * @psalm-var array<non-empty-string, list<string>>
+     * @psalm-var array<non-empty-string|int, list<string>>
      */
     protected $headers = [];
 
@@ -340,6 +341,7 @@ trait MessageTrait
 
             $this->assertHeader($header);
 
+            $header                           = is_int($header) ? (string) $header : $header;
             $headerNames[strtolower($header)] = $header;
             $headers[$header]                 = $value;
         }

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -104,7 +104,7 @@ trait MessageTrait
      *
      * @return array Returns an associative array of the message's headers. Each
      *     key MUST be a header name, and each value MUST be an array of strings.
-     * @psalm-return array<non-empty-string, list<string>>
+     * @psalm-return array<non-empty-string|int, list<string>>
      */
     public function getHeaders(): array
     {

--- a/src/RequestTrait.php
+++ b/src/RequestTrait.php
@@ -9,6 +9,7 @@ use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
 
 use function array_keys;
+use function is_int;
 use function is_string;
 use function preg_match;
 use function sprintf;
@@ -262,6 +263,10 @@ trait RequestTrait
         // de-normalization of the header name.
         // @see https://github.com/zendframework/zend-diactoros/issues/91
         foreach (array_keys($new->headers) as $header) {
+            if (is_int($header)) {
+                continue;
+            }
+
             if (strtolower($header) === 'host') {
                 unset($new->headers[$header]);
             }

--- a/test/HeaderSecurityTest.php
+++ b/test/HeaderSecurityTest.php
@@ -131,19 +131,18 @@ final class HeaderSecurityTest extends TestCase
         HeaderSecurity::assertValidName($value);
     }
 
-    /** @psalm-return non-empty-array<non-empty-string, array{0: int|float}> */
+    /** @psalm-return non-empty-array<non-empty-string, array{0: int}> */
     public function provideValidNumericHeaderNameValues(): array
     {
         return [
-            'zero'       => [0],
-            'int'        => [1],
-            'zero-float' => [0.0],
-            'float'      => [1.1],
+            'negative' => [-1],
+            'zero'     => [0],
+            'int'      => [1],
         ];
     }
 
     /** @dataProvider provideValidNumericHeaderNameValues */
-    public function testAssertValidNameDoesNotRaiseExceptionForValidNumericValues(int|float $value): void
+    public function testAssertValidNameDoesNotRaiseExceptionForValidNumericValues(int $value): void
     {
         $this->assertNull(HeaderSecurity::assertValidName($value));
     }

--- a/test/HeaderSecurityTest.php
+++ b/test/HeaderSecurityTest.php
@@ -130,4 +130,21 @@ final class HeaderSecurityTest extends TestCase
 
         HeaderSecurity::assertValidName($value);
     }
+
+    /** @psalm-return non-empty-array<non-empty-string, array{0: int|float}> */
+    public function provideValidNumericHeaderNameValues(): array
+    {
+        return [
+            'zero'       => [0],
+            'int'        => [1],
+            'zero-float' => [0.0],
+            'float'      => [1.1],
+        ];
+    }
+
+    /** @dataProvider provideValidNumericHeaderNameValues */
+    public function testAssertValidNameDoesNotRaiseExceptionForValidNumericValues(int|float $value): void
+    {
+        $this->assertNull(HeaderSecurity::assertValidName($value));
+    }
 }

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -185,11 +185,10 @@ final class RequestTest extends TestCase
     public function invalidHeaderTypes(): array
     {
         return [
-            'indexed-array' => [[['INVALID']], 'header name'],
-            'null'          => [['x-invalid-null' => null]],
-            'true'          => [['x-invalid-true' => true]],
-            'false'         => [['x-invalid-false' => false]],
-            'object'        => [['x-invalid-object' => (object) ['INVALID']]],
+            'null'   => [['x-invalid-null' => null]],
+            'true'   => [['x-invalid-true' => true]],
+            'false'  => [['x-invalid-false' => false]],
+            'object' => [['x-invalid-object' => (object) ['INVALID']]],
         ];
     }
 

--- a/test/ResponseTest.php
+++ b/test/ResponseTest.php
@@ -276,11 +276,10 @@ final class ResponseTest extends TestCase
     public function invalidHeaderTypes(): array
     {
         return [
-            'indexed-array' => [[['INVALID']], 'header name'],
-            'null'          => [['x-invalid-null' => null]],
-            'true'          => [['x-invalid-true' => true]],
-            'false'         => [['x-invalid-false' => false]],
-            'object'        => [['x-invalid-object' => (object) ['INVALID']]],
+            'null'   => [['x-invalid-null' => null]],
+            'true'   => [['x-invalid-true' => true]],
+            'false'  => [['x-invalid-false' => false]],
+            'object' => [['x-invalid-object' => (object) ['INVALID']]],
         ];
     }
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | yes
| New Feature   | no
| RFC           | no
| QA            | no

### Description

RFC 7230 allows for numeric header names, both integers and floats, though the expectation is that they are provided as string values. Since PHP casts integer strings into integers for purposes of array keys, this can lead to a scenario where `HeaderSecurity` was then flagging the value as invalid - despite the fact that the regex used on strings clearly allows the value. This patch modifies `HeaderSecurity::assertValidName()` to allow for numeric names, and casts them to a string when performing validations.

Marking as a BC break as there is a subtle behavior change.

Fixes #11
