### PR TITLE
Ensure fromGlobals does not use superglobals when passed empty arrays

### DIFF
--- a/docs/book/v3/migration.md
+++ b/docs/book/v3/migration.md
@@ -1,5 +1,14 @@
 # Migration to Version 3
 
+## Changed
+
+The following features were changed in version 3.
+
+### ServerRequestFactory::fromGlobals
+
+The factory `Laminas\Diactoros\ServerRequestFactory::fromGlobals()` was modified such that passing empty array values for arguments that accept `null` or an array now will not use the associated superglobal in that scenario.
+Previously, an empty array value was treated as identical to `null`, and would cause the factory to fallback to superglobals; now, this is a way to provide an empty set for the associated value(s).
+
 ## Removed
 
 The following features were removed for version 3.

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -185,20 +185,6 @@
     </DocblockTypeContradiction>
   </file>
   <file src="src/ServerRequestFactory.php">
-    <LessSpecificReturnStatement>
-      <code><![CDATA[$requestFilter(new ServerRequest(
-            $server,
-            $files,
-            UriFactory::createFromSapi($server, $headers),
-            marshalMethodFromSapi($server),
-            'php://input',
-            $headers,
-            $cookies ?: $_COOKIE,
-            $query ?: $_GET,
-            $body ?: $_POST,
-            marshalProtocolVersionFromSapi($server)
-        ))]]></code>
-    </LessSpecificReturnStatement>
     <MixedArgument>
       <code><![CDATA[$headers['cookie']]]></code>
     </MixedArgument>
@@ -206,9 +192,6 @@
       <code>$headers</code>
       <code>$server</code>
     </MixedArgumentTypeCoercion>
-    <MoreSpecificReturnType>
-      <code>ServerRequest</code>
-    </MoreSpecificReturnType>
     <RedundantConditionGivenDocblockType>
       <code>is_callable(self::$apacheRequestHeaders)</code>
     </RedundantConditionGivenDocblockType>

--- a/src/ServerRequestFactory.php
+++ b/src/ServerRequestFactory.php
@@ -53,14 +53,14 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
         ?array $cookies = null,
         ?array $files = null,
         ?FilterServerRequestInterface $requestFilter = null
-    ): ServerRequest {
-        $requestFilter = $requestFilter ?: FilterUsingXForwardedHeaders::trustReservedSubnets();
+    ): ServerRequestInterface {
+        $requestFilter = $requestFilter ?? FilterUsingXForwardedHeaders::trustReservedSubnets();
 
         $server  = normalizeServer(
-            $server ?: $_SERVER,
+            $server ?? $_SERVER,
             is_callable(self::$apacheRequestHeaders) ? self::$apacheRequestHeaders : null
         );
-        $files   = normalizeUploadedFiles($files ?: $_FILES);
+        $files   = normalizeUploadedFiles($files ?? $_FILES);
         $headers = marshalHeadersFromSapi($server);
 
         if (null === $cookies && array_key_exists('cookie', $headers)) {
@@ -74,9 +74,9 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
             marshalMethodFromSapi($server),
             'php://input',
             $headers,
-            $cookies ?: $_COOKIE,
-            $query ?: $_GET,
-            $body ?: $_POST,
+            $cookies ?? $_COOKIE,
+            $query ?? $_GET,
+            $body ?? $_POST,
             marshalProtocolVersionFromSapi($server)
         ));
     }

--- a/test/ServerRequestFactoryTest.php
+++ b/test/ServerRequestFactoryTest.php
@@ -19,6 +19,9 @@ use function Laminas\Diactoros\normalizeServer;
 use function Laminas\Diactoros\normalizeUploadedFiles;
 use function str_replace;
 
+/**
+ * @backupGlobals enabled
+ */
 final class ServerRequestFactoryTest extends TestCase
 {
     public function testReturnsServerValueUnchangedIfHttpAuthorizationHeaderIsPresent(): void

--- a/test/ServerRequestFactoryTest.php
+++ b/test/ServerRequestFactoryTest.php
@@ -130,6 +130,44 @@ final class ServerRequestFactoryTest extends TestCase
         $this->assertSame('1.1', $request->getProtocolVersion());
     }
 
+    public function testFromGlobalsShouldNotFallbackToSuperGlobalsWithEmptyArray(): void
+    {
+        $_SERVER = [
+            'SERVER_PROTOCOL' => '1',
+            'HTTP_HOST'       => 'example.com',
+            'HTTP_ACCEPT'     => 'application/json',
+            'REQUEST_METHOD'  => 'POST',
+            'REQUEST_URI'     => '/foo/bar',
+            'QUERY_STRING'    => 'bar=baz',
+        ];
+
+        $_COOKIE = $_GET = $_POST = [
+            'bar' => 'baz',
+        ];
+
+        $_COOKIE['cookies'] = true;
+        $_GET['query']      = true;
+        $_POST['body']      = true;
+        $_FILES             = [
+            'files' => [
+                'tmp_name' => 'php://temp',
+                'size'     => 0,
+                'error'    => 0,
+                'name'     => 'foo.bar',
+                'type'     => 'text/plain',
+            ],
+        ];
+
+        $request = ServerRequestFactory::fromGlobals([], [], [], [], []);
+        $this->assertEmpty($request->getServerParams(), 'Server params are not empty');
+        $this->assertEmpty($request->getQueryParams(), 'Query params are not empty');
+        $this->assertEmpty($request->getParsedBody(), 'Parsed body is not empty');
+        $this->assertEmpty($request->getCookieParams(), 'Cookies are not empty');
+        $this->assertEmpty($request->getUploadedFiles(), 'Uploaded files are not empty');
+        $defaults = new ServerRequest();
+        $this->assertSame($defaults->getProtocolVersion(), $request->getProtocolVersion());
+    }
+
     public function testFromGlobalsUsesCookieHeaderInsteadOfCookieSuperGlobal(): void
     {
         $_COOKIE                = [


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | yes
| New Feature   | no
| RFC           | no
| QA            | no

### Description

`ServerRequestFactory::fromGlobals()` currently falls back to superglobals on null or when empty array is passed as an argument.

This change ensures fallback to superglobals only happens with null. 