### PR TITLE
Document PSR-7 v2 impact

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,8 +51,8 @@
         "vimeo/psalm": "^5.9"
     },
     "provide": {
-        "psr/http-factory-implementation": "1.0",
-        "psr/http-message-implementation": "1.0"
+        "psr/http-factory-implementation": "^1.1 || ^2.0",
+        "psr/http-message-implementation": "1.1 || ^2.0"
     },
     "autoload": {
         "files": [

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
     },
     "provide": {
         "psr/http-factory-implementation": "^1.1 || ^2.0",
-        "psr/http-message-implementation": "1.1 || ^2.0"
+        "psr/http-message-implementation": "^1.1 || ^2.0"
     },
     "autoload": {
         "files": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c0dbef991657278ec00fc58f809172f3",
+    "content-hash": "d03e212f295e0322fb33f43bfd225d31",
     "packages": [
         {
             "name": "psr/http-factory",
@@ -3998,16 +3998,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "5.9.0",
+            "version": "5.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "8b9ad1eb9e8b7d3101f949291da2b9f7767cd163"
+                "reference": "a5effd2d2dddd1a7ea7a0f6a051ce63ff979e356"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/8b9ad1eb9e8b7d3101f949291da2b9f7767cd163",
-                "reference": "8b9ad1eb9e8b7d3101f949291da2b9f7767cd163",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/a5effd2d2dddd1a7ea7a0f6a051ce63ff979e356",
+                "reference": "a5effd2d2dddd1a7ea7a0f6a051ce63ff979e356",
                 "shasum": ""
             },
             "require": {
@@ -4098,9 +4098,9 @@
             ],
             "support": {
                 "issues": "https://github.com/vimeo/psalm/issues",
-                "source": "https://github.com/vimeo/psalm/tree/5.9.0"
+                "source": "https://github.com/vimeo/psalm/tree/5.10.0"
             },
-            "time": "2023-03-29T21:38:21+00:00"
+            "time": "2023-05-02T17:20:34+00:00"
         },
         {
             "name": "webimpress/coding-standard",

--- a/docs/book/v3/migration.md
+++ b/docs/book/v3/migration.md
@@ -4,6 +4,21 @@
 
 The following features were changed in version 3.
 
+### PSR-7 v2 support
+
+This version adds support for PSR-7 version 2.
+
+Diactoros 2.25.0 added support for PSR-7 version 1.1, and at that time, already had return type declarations that would mostly fulfill PSR-7 version 2.
+However, there were two locations in PSR-7 where `void` returns were added:
+
+- `StreamInterface::seek()`
+- `UploadedFileInterface::moveTo()`
+
+Since absence of a return type declaration implies `mixed` in PHP, switching to `void` is always considered a BC break, as it reduces the allowed behavior.
+As such, any consumers _extending_ our `Stream` or `UploadedFile` classes and overriding either of these methods would experience a BC breaking change due to types.
+
+For consumers, usage should be completely backwards compatible, however.
+
 ### ServerRequestFactory::fromGlobals
 
 The factory `Laminas\Diactoros\ServerRequestFactory::fromGlobals()` was modified such that passing empty array values for arguments that accept `null` or an array now will not use the associated superglobal in that scenario.


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

This patch is primarily documentation, and does the following:

- Updates the Composer `provide` section to use the constraint `^1.1 || ^2.0` for each of psr/http-message and http-factory
- Adds a section to the migration document to detail PSR-7 v2 adoption impact
