### PR TITLE
Fix docs referring to array key as value

### DIFF
--- a/docs/book/v3/security.md
+++ b/docs/book/v3/security.md
@@ -26,7 +26,7 @@ RFC-7230 defines an ABNF pattern for header field names that allows the possibil
 ```
 
 The PSR-7, `Psr\Http\MessageInterface::getHeaders()` method requires implementations to return an associative array, where the key is the header field name.
-This triggers an interesting quirk in PHP: when adding a value to an array using a string that consists of an integer value, PHP will convert this value to an integer (see [PHP bug 80309](https://bugs.php.net/bug.php?id=80309) for more details).
+This triggers an interesting quirk in PHP: when adding an element to an array with a string key that consists of an integer value, PHP will convert this key to an integer (see [PHP bug 80309](https://bugs.php.net/bug.php?id=80309) for more details).
 This presents several issues:
 
 - First, it means that consumers cannot depend on the header field name returned being a string.


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description
Problematic behavior is exhibited by the array key but documentation implies the value will be converted instead.