### PR TITLE
Don't ignore platform requirements on 8.3

### DIFF
--- a/.laminas-ci.json
+++ b/.laminas-ci.json
@@ -1,8 +1,5 @@
 {
     "extensions": [
         "gd"
-    ],
-    "ignore_php_platform_requirements": {
-        "8.3": true
-    }
+    ]
 }

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         "php-http/psr7-integration-tests": "^1.3",
         "phpunit/phpunit": "^9.5.28",
         "psalm/plugin-phpunit": "^0.18.4",
-        "vimeo/psalm": "^5.9"
+        "vimeo/psalm": "^5.15.0"
     },
     "provide": {
         "psr/http-factory-implementation": "^1.1 || ^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3d9aab599e93760956ac4a0139b50f18",
+    "content-hash": "94fc7b9ce4d8d14a65385b4efca30737",
     "packages": [
         {
             "name": "psr/http-factory",


### PR DESCRIPTION
All dependencies support PHP 8.3 - Psalm is bumped to 5.15

|    Q          |   A
|-------------- | ------
| QA            | yes

