### PR TITLE
Fix cookie parsing from headers in server request factory using globals.

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.25.0@01a8eb06b9e9cc6cfb6a320bf9fb14331919d505">
+<files psalm-version="5.26.0@4787eaf414e16c661902b94dfe5d882223e5b513">
   <file src="src/AbstractSerializer.php">
     <RedundantCondition>
       <code><![CDATA[! $crFound]]></code>
@@ -190,9 +190,6 @@
       <code><![CDATA[$headers]]></code>
       <code><![CDATA[$server]]></code>
     </MixedArgumentTypeCoercion>
-    <RedundantConditionGivenDocblockType>
-      <code><![CDATA[is_callable(self::$apacheRequestHeaders)]]></code>
-    </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/ServerRequestFilter/FilterUsingXForwardedHeaders.php">
     <ImpureMethodCall>

--- a/src/ServerRequestFactory.php
+++ b/src/ServerRequestFactory.php
@@ -20,7 +20,7 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
     /**
      * Function to use to get apache request headers; present only to simplify mocking.
      *
-     * @var callable
+     * @var callable|string
      */
     private static $apacheRequestHeaders = 'apache_request_headers';
 
@@ -35,11 +35,11 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
      *
      * @see fromServer()
      *
-     * @param array $server $_SERVER superglobal
-     * @param array $query $_GET superglobal
-     * @param array $body $_POST superglobal
-     * @param array $cookies $_COOKIE superglobal
-     * @param array $files $_FILES superglobal
+     * @param null|array $server $_SERVER superglobal
+     * @param null|array $query $_GET superglobal
+     * @param null|array $body $_POST superglobal
+     * @param null|array $cookies $_COOKIE superglobal
+     * @param null|array $files $_FILES superglobal
      * @param null|FilterServerRequestInterface $requestFilter If present, the
      *     generated request will be passed to this instance and the result
      *     returned by this method. When not present, a default instance of

--- a/src/functions/parse_cookie_header.php
+++ b/src/functions/parse_cookie_header.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Laminas\Diactoros;
 
 use function preg_match_all;
-use function urldecode;
+use function rawurldecode;
 
 use const PREG_SET_ORDER;
 
@@ -33,7 +33,7 @@ function parseCookieHeader($cookieHeader): array
     $cookies = [];
 
     foreach ($matches as $match) {
-        $cookies[$match['name']] = urldecode($match['value']);
+        $cookies[$match['name']] = rawurldecode($match['value']);
     }
 
     return $cookies;

--- a/test/ServerRequestFactoryTest.php
+++ b/test/ServerRequestFactoryTest.php
@@ -243,7 +243,7 @@ final class ServerRequestFactoryTest extends TestCase
             ],
             'url-encoded-value'   => [
                 'foo=bar%3B+',
-                ['foo' => 'bar; '],
+                ['foo' => 'bar;+'],
             ],
             'double-quoted-value' => [
                 'foo="bar"',


### PR DESCRIPTION
PHP used to encode space in cookie values as + in violation of RFCs until it was fixed in PHP 7.4.
See https://bugs.php.net/bug.php?id=79174

We decode headers to read server request cookies when creating server request from globals. It was still converting `+` in the cookie value back to space.

This PR fixes our implementation to align it again with the supported PHP versions and RFCs.