### PR TITLE
Fix provided versions of psr/http-factory-implementation in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "vimeo/psalm": "^5.25.0"
     },
     "provide": {
-        "psr/http-factory-implementation": "^1.1 || ^2.0",
+        "psr/http-factory-implementation": "^1.0",
         "psr/http-message-implementation": "^1.1 || ^2.0"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dec0725e4210a2f8714e9976a18ad861",
+    "content-hash": "e5b673582a8569a858a0298c119d3a96",
     "packages": [
         {
             "name": "psr/http-factory",


### PR DESCRIPTION
None of the provided versions of the virtual package psr/http-factory-implementation exist in psr/http-factory. Particularly there is no v2 version.

Original change was meant for the psr/http-message-implementation but got inadvertently duplicated.