### PR TITLE
Fix error while trying to get stream metadata after detach

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -214,8 +214,6 @@
     <PossiblyNullArgument>
       <code><![CDATA[$resource]]></code>
       <code><![CDATA[$this->resource]]></code>
-      <code><![CDATA[$this->resource]]></code>
-      <code><![CDATA[$this->resource]]></code>
     </PossiblyNullArgument>
     <PossiblyUnusedProperty>
       <code><![CDATA[$stream]]></code>

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -297,11 +297,15 @@ class Stream implements StreamInterface, Stringable
      */
     public function getMetadata(?string $key = null)
     {
-        if (null === $key) {
-            return stream_get_meta_data($this->resource);
+        $metadata = [];
+        if (null !== $this->resource) {
+            $metadata = stream_get_meta_data($this->resource);
         }
 
-        $metadata = stream_get_meta_data($this->resource);
+        if (null === $key) {
+            return $metadata;
+        }
+
         if (! array_key_exists($key, $metadata)) {
             return null;
         }

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -24,9 +24,9 @@ use function is_int;
 use function is_resource;
 use function is_string;
 use function sprintf;
+use function str_contains;
 use function stream_get_contents;
 use function stream_get_meta_data;
-use function strstr;
 
 use const SEEK_SET;
 
@@ -210,11 +210,11 @@ class Stream implements StreamInterface, Stringable
         $meta = stream_get_meta_data($this->resource);
         $mode = $meta['mode'];
 
-        return strstr($mode, 'x') !== false
-            || strstr($mode, 'w') !== false
-            || strstr($mode, 'c') !== false
-            || strstr($mode, 'a') !== false
-            || strstr($mode, '+') !== false;
+        return str_contains($mode, 'x')
+            || str_contains($mode, 'w')
+            || str_contains($mode, 'c')
+            || str_contains($mode, 'a')
+            || str_contains($mode, '+');
     }
 
     /**
@@ -251,7 +251,7 @@ class Stream implements StreamInterface, Stringable
         $meta = stream_get_meta_data($this->resource);
         $mode = $meta['mode'];
 
-        return strstr($mode, 'r') !== false || strstr($mode, '+') !== false;
+        return str_contains($mode, 'r') || str_contains($mode, '+');
     }
 
     /**

--- a/test/StreamTest.php
+++ b/test/StreamTest.php
@@ -596,6 +596,16 @@ final class StreamTest extends TestCase
         $this->assertSame($expected, $test);
     }
 
+    public function testGetMetadataReturnsEmptyArrayAfterDetach(): void
+    {
+        self::assertNotEmpty($this->stream->getMetadata());
+        self::assertNotEmpty($this->stream->getMetadata('mode'));
+
+        $this->stream->detach();
+        self::assertSame([], $this->stream->getMetadata());
+        self::assertNull($this->stream->getMetadata('mode'));
+    }
+
     public function testGetMetadataReturnsDataForSpecifiedKey(): void
     {
         $this->tmpnam = tempnam(sys_get_temp_dir(), 'diac');


### PR DESCRIPTION
Fix error trying to get stream metadata after it was detached. Ensure empty array or null for the key are returned while stream is detached.