### PR TITLE
Add basic host validation in Uri and add port validation to the Uri constructor

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -408,6 +408,7 @@
     </MixedAssignment>
     <PossiblyUnusedMethod>
       <code><![CDATA[authorityInfo]]></code>
+      <code><![CDATA[invalidHosts]]></code>
       <code><![CDATA[invalidPaths]]></code>
       <code><![CDATA[invalidQueryStrings]]></code>
       <code><![CDATA[invalidUriProvider]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -406,6 +406,19 @@
     <MixedAssignment>
       <code><![CDATA[$test]]></code>
     </MixedAssignment>
+    <PossiblyUnusedMethod>
+      <code><![CDATA[authorityInfo]]></code>
+      <code><![CDATA[invalidPaths]]></code>
+      <code><![CDATA[invalidQueryStrings]]></code>
+      <code><![CDATA[invalidUriProvider]]></code>
+      <code><![CDATA[mutations]]></code>
+      <code><![CDATA[queryStringsForEncoding]]></code>
+      <code><![CDATA[standardSchemePortCombinations]]></code>
+      <code><![CDATA[userInfoProvider]]></code>
+      <code><![CDATA[utf8PathsDataProvider]]></code>
+      <code><![CDATA[utf8QueryStringsDataProvider]]></code>
+      <code><![CDATA[validPorts]]></code>
+    </PossiblyUnusedMethod>
     <PossiblyUnusedParam>
       <code><![CDATA[$query]]></code>
     </PossiblyUnusedParam>


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Assuming the current release is 1.5.0, the next patch release is 1.5.1, the next minor is 1.6.0 and the next major is 2.0.0, The Current release branch will be `1.5.x`, the next minor branch will be `1.6.x`, and the next major branch will be `2.0.x`

Pick the target branch based on the following criteria:
  * Documentation improvement: Current release branch 1.5.x
  * Bugfix: Current release branch 1.5.x
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: Next minor 1.6.x
  * New feature, or refactor of existing code: Next minor 1.6.x
  * Backwards incompatible features and refactoring: Next major 2.0.x

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | yes/no
| New Feature   | no
| RFC           | yes
| QA            | no

### Description

This change introduces validation for the uri host as `parse_url()` does not validate host subcomponent permitting outright forbidden characters to be used.

This PR introduces basic host subcomponent validation that would reject forbidden characters, validate IPv6 address and wrap it the square brackets. 
This validation does not ensure hostname is actually valid. For example, URI allows various sub-delimeters  and percent encoding which would be invalid in the context of the http urls. This validation does not prevent them and it does not validate percent encoding is actually valid.

See [RFC3986 3.2.2](https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.2)

Port validation was added to the Uri constructor as `parse_url()` would allow port 0 which is a wildcard port not valid for the Uri.