### PR TITLE
Updating cookie-parsing regex to be more aligned with RFC 6265

### DIFF
--- a/src/functions/parse_cookie_header.php
+++ b/src/functions/parse_cookie_header.php
@@ -21,13 +21,13 @@ use const PREG_SET_ORDER;
 function parseCookieHeader($cookieHeader): array
 {
     preg_match_all('(
-        (?:^\\n?[ \t]*|;[ ])
-        (?P<name>[!#$%&\'*+-.0-9A-Z^_`a-z|~]+)
+        (?:^\\n?[ \t]*|;[ \t]*)
+        (?P<name>[!#$%&\'*+-.0-9A-Z^_`a-z|~\[\]]+)
         =
         (?P<DQUOTE>"?)
             (?P<value>[\x21\x23-\x2b\x2d-\x3a\x3c-\x5b\x5d-\x7e]*)
         (?P=DQUOTE)
-        (?=\\n?[ \t]*$|;[ ])
+        (?=\\n?[ \t]*$|;[ \t]*)
     )x', $cookieHeader, $matches, PREG_SET_ORDER);
 
     $cookies = [];

--- a/test/ServerRequestFactoryTest.php
+++ b/test/ServerRequestFactoryTest.php
@@ -234,29 +234,37 @@ final class ServerRequestFactoryTest extends TestCase
     public static function cookieHeaderValues(): array
     {
         return [
-            'ows-without-fold'    => [
+            'ows-without-fold'        => [
                 "\tfoo=bar ",
                 ['foo' => 'bar'],
             ],
-            'url-encoded-value'   => [
+            'url-encoded-value'       => [
                 'foo=bar%3B+',
                 ['foo' => 'bar;+'],
             ],
-            'double-quoted-value' => [
+            'double-quoted-value'     => [
                 'foo="bar"',
                 ['foo' => 'bar'],
             ],
-            'multiple-pairs'      => [
+            'multiple-pairs'          => [
                 'foo=bar; baz="bat"; bau=bai',
                 ['foo' => 'bar', 'baz' => 'bat', 'bau' => 'bai'],
             ],
-            'same-name-pairs'     => [
+            'same-name-pairs'         => [
                 'foo=bar; foo="bat"',
                 ['foo' => 'bat'],
             ],
-            'period-in-name'      => [
+            'period-in-name'          => [
                 'foo.bar=baz',
                 ['foo.bar' => 'baz'],
+            ],
+            'no-space-separator'      => [
+                'foo=bar;bar=baz',
+                ['foo' => 'bar', 'bar' => 'baz'],
+            ],
+            'square-brackets-in-name' => [
+                'foo[bar]=bar;foo[baz]=baz',
+                ['foo[bar]' => 'bar', 'foo[baz]' => 'baz'],
             ],
         ];
     }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | yes/no
| New Feature   | no
| RFC           | no
| QA            | yes/no

### Description

Regex inside `parseCookieHeader` is not totally in alignment with RFC 6265. This PR aims to fix two moments:
1. When cookie header does not have a space in between values, e.g. `test1=test;test2=test`. Previously this led to an empty cookie array (or in versions less than `3.*` to a fallback using `$_COOKIE` array).
2. When cookie header contains square brackets in names, e.g. `test[test1]=test; test[test2]=test2`. This should solve an exissting issue, I believe: https://github.com/laminas/laminas-diactoros/issues/7.

I've added tests for these cases.