### PR TITLE
Fix “Unsafe usage of new static()” by making EmptyResponse final

### DIFF
--- a/src/Response/EmptyResponse.php
+++ b/src/Response/EmptyResponse.php
@@ -10,7 +10,7 @@ use Laminas\Diactoros\Stream;
 /**
  * A class representing empty HTTP responses.
  */
-class EmptyResponse extends Response
+final class EmptyResponse extends Response
 {
     /**
      * Create an empty response with the given status code.


### PR DESCRIPTION
Marking EmptyResponse as final prevents late static binding issues
when instantiating with `new static()`, ensuring type safety and
avoiding potential runtime errors in subclasses.

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | yes
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Marking EmptyResponse as final prevents late static binding issues
when instantiating with `new static()`, ensuring type safety and
avoiding potential runtime errors in subclasses.