### PR TITLE
Optimize CIDR parsing for performance

### DIFF
--- a/src/Response/EmptyResponse.php
+++ b/src/Response/EmptyResponse.php
@@ -10,7 +10,7 @@ use Laminas\Diactoros\Stream;
 /**
  * A class representing empty HTTP responses.
  */
-final class EmptyResponse extends Response
+class EmptyResponse extends Response
 {
     /**
      * Create an empty response with the given status code.

--- a/src/Response/EmptyResponse.php
+++ b/src/Response/EmptyResponse.php
@@ -10,7 +10,7 @@ use Laminas\Diactoros\Stream;
 /**
  * A class representing empty HTTP responses.
  */
-class EmptyResponse extends Response
+final class EmptyResponse extends Response
 {
     /**
      * Create an empty response with the given status code.

--- a/src/ServerRequestFilter/FilterUsingXForwardedHeaders.php
+++ b/src/ServerRequestFilter/FilterUsingXForwardedHeaders.php
@@ -233,10 +233,10 @@ final class FilterUsingXForwardedHeaders implements FilterServerRequestInterface
 
         $address = $cidr;
         $mask    = null;
-        if (str_contains($cidr, '/')) {
-            $parts = explode('/', $cidr, 2);
-            [$address, $mask] = $parts;
-            $mask             = (int) $mask;
+        $pos = strpos($cidr, '/');
+        if ($pos !== false) {
+            $address = substr($cidr, 0, $pos);
+            $mask    = (int) substr($cidr, $pos + 1);
         }
 
         if (str_contains($address, ':')) {

--- a/src/ServerRequestFilter/FilterUsingXForwardedHeaders.php
+++ b/src/ServerRequestFilter/FilterUsingXForwardedHeaders.php
@@ -235,7 +235,6 @@ final class FilterUsingXForwardedHeaders implements FilterServerRequestInterface
         $mask    = null;
         if (str_contains($cidr, '/')) {
             $parts = explode('/', $cidr, 2);
-            assert(count($parts) >= 2);
             [$address, $mask] = $parts;
             $mask             = (int) $mask;
         }

--- a/src/ServerRequestFilter/FilterUsingXForwardedHeaders.php
+++ b/src/ServerRequestFilter/FilterUsingXForwardedHeaders.php
@@ -9,14 +9,13 @@ use Laminas\Diactoros\Exception\InvalidProxyAddressException;
 use Laminas\Diactoros\UriFactory;
 use Psr\Http\Message\ServerRequestInterface;
 
-use function assert;
-use function count;
-use function explode;
 use function filter_var;
 use function in_array;
 use function is_string;
 use function str_contains;
+use function strpos;
 use function strtolower;
+use function substr;
 
 use const FILTER_FLAG_IPV4;
 use const FILTER_FLAG_IPV6;
@@ -233,7 +232,7 @@ final class FilterUsingXForwardedHeaders implements FilterServerRequestInterface
 
         $address = $cidr;
         $mask    = null;
-        $pos = strpos($cidr, '/');
+        $pos     = strpos($cidr, '/');
         if ($pos !== false) {
             $address = substr($cidr, 0, $pos);
             $mask    = (int) substr($cidr, $pos + 1);


### PR DESCRIPTION
Replaced explode() with strpos() and substr() to avoid creating an array,
reducing memory usage and improving parsing speed.

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

<img width="553" height="403" alt="per" src="https://github.com/user-attachments/assets/52ea3457-99a0-4dce-bab7-12cef0caa474" />

Tested xdebug with following code. 

```php
<?php
 

 function validateProxyCIDR_explode(mixed $cidr): bool
    {
        if (! is_string($cidr) || '' === $cidr) {
            return false;
        }

        $address = $cidr;
        $mask    = null;
        if (str_contains($cidr, '/')) { 
            $parts = explode('/', $cidr, 2); 
            assert(count($parts) >= 2); 
            [$address, $mask] = $parts; 
            $mask = (int) $mask; 
        }

        if (str_contains($address, ':')) {
            // is IPV6
            return filter_var($address, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)
                && (
                    $mask === null
                    || (
                        $mask <= 128
                        && $mask >= 0
                    )
                );
        }

        // is IPV4
        return filter_var($address, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)
            && (
                $mask === null
                || (
                    $mask <= 32
                    && $mask >= 0
                )
            );
    }





function validateProxyCIDR_str(mixed $cidr): bool
    {
        if (! is_string($cidr) || '' === $cidr) {
            return false;
        }

        $address = $cidr;
        $mask    = null;
        $pos = strpos($cidr, '/');
        if ($pos !== false) {
            $address = substr($cidr, 0, $pos);
            $mask    = (int) substr($cidr, $pos + 1);
        }

        if (str_contains($address, ':')) {
            // is IPV6
            return filter_var($address, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)
                && (
                    $mask === null
                    || (
                        $mask <= 128
                        && $mask >= 0
                    )
                );
        }

        // is IPV4
        return filter_var($address, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)
            && (
                $mask === null
                || (
                    $mask <= 32
                    && $mask >= 0
                )
            );
    }



// Sample test data

$cidrs = [
    '192.168.0.1',
    '10.0.0.0/8',
    '172.16.0.0/12',
    'invalid',
    '',
];

    // Benchmark loop
$iterations = 1_000;
$start = hrtime(true);

for ($i = 0; $i < $iterations; $i++) {
    foreach ($cidrs as $cidr) {
        validateProxyCIDR_str($cidr);
        validateProxyCIDR_explode($cidr);
    }
}

$end = hrtime(true);
$time_ns = $end - $start;
$time_ms = $time_ns / 1_000_000;

echo "Executed $iterations iterations in {$time_ms} ms\n";
```
