### PR TITLE
Allow HTTP/3 protocol versions

### DIFF
--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -355,9 +355,9 @@ trait MessageTrait
             );
         }
 
-        // HTTP/1 uses a "<major>.<minor>" numbering scheme to indicate
-        // versions of the protocol, while HTTP/2 does not.
-        if (! preg_match('#^(1\.[01]|2(\.0)?)$#', $version)) {
+        // Accept HTTP/1.x and the compact or ".0" representations
+        // of HTTP/2 and HTTP/3.
+        if (! preg_match('#^(?:1\.[01]|[23](?:\.0)?)\z#', $version)) {
             throw new Exception\InvalidArgumentException(sprintf(
                 'Unsupported HTTP protocol version "%s" provided',
                 $version

--- a/test/MessageTraitTest.php
+++ b/test/MessageTraitTest.php
@@ -46,6 +46,8 @@ final class MessageTraitTest extends TestCase
             '1-without-minor'      => ['1'],
             '1-with-invalid-minor' => ['1.2'],
             '1-with-hotfix'        => ['1.1.1'],
+            '3-with-invalid-minor' => ['3.1'],
+            '3-with-hotfix'        => ['3.0.1'],
         ];
     }
 
@@ -65,6 +67,7 @@ final class MessageTraitTest extends TestCase
             '1.1' => ['1.1'],
             '2'   => ['2'],
             '2.0' => ['2.0'],
+            '3.0' => ['3.0'],
         ];
     }
 


### PR DESCRIPTION
## Description

Update protocol version validation to accept HTTP/3 protocol versions.

`MessageTrait::validateProtocolVersion()` currently accepts the following values:

* `1.0`
* `1.1`
* `2`
* `2.0`

However, passing `3` to `withProtocolVersion()` results in an `InvalidArgumentException`.

This change adds support for both `3` and `3.0`, following the existing handling of HTTP/2.
